### PR TITLE
Athena operator

### DIFF
--- a/dagger/conf.py
+++ b/dagger/conf.py
@@ -86,6 +86,7 @@ ATHENA_AWS_CONN_ID = athena_config.get('aws_conn_id', None)
 ATHENA_DEFAULT_S3_OUTPUT_LOCATION = athena_config.get('default_s3_output_location', None)
 ATHENA_S3_TMP_RESULTS_LOCATION = athena_config.get('s3_tmp_results_location', None)
 ATHENA_DEFAULT_WORKGROUP = athena_config.get('workgroup', None)
+ATHENA_DEFAULT_OUTPUT_FORMAT = athena_config.get('default_output_format', None)
 
 # Sqoop
 sqoop_config = config.get('sqoop', None) or {}

--- a/dagger/conf.py
+++ b/dagger/conf.py
@@ -80,6 +80,13 @@ BATCH_CLUSTER_NAME = batch_config.get('cluster_name', None)
 BATCH_AWS_CONN_ID = batch_config.get('aws_conn_id', None)
 BATCH_DEFAULT_QUEUE = batch_config.get('default_queue', None)
 
+# Athena
+athena_config = config.get('athena', None) or {}
+ATHENA_AWS_CONN_ID = athena_config.get('aws_conn_id', None)
+ATHENA_DEFAULT_S3_OUTPUT_LOCATION = athena_config.get('default_s3_output_location', None)
+ATHENA_S3_TMP_RESULTS_LOCATION = athena_config.get('s3_tmp_results_location', None)
+ATHENA_DEFAULT_WORKGROUP = athena_config.get('workgroup', None)
+
 # Sqoop
 sqoop_config = config.get('sqoop', None) or {}
 SQOOP_DEFAULT_FORMAT = sqoop_config.get('default_file_format', "avro")

--- a/dagger/dag_creator/airflow/hooks/aws_athena_hook.py
+++ b/dagger/dag_creator/airflow/hooks/aws_athena_hook.py
@@ -1,0 +1,220 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+This module contains AWS Athena hook
+"""
+from time import sleep
+from airflow.contrib.hooks.aws_hook import AwsHook
+from os import path
+
+from botocore.exceptions import ClientError
+
+
+class AWSAthenaHook(AwsHook):
+    """
+    Interact with AWS Athena to run, poll queries and return query results
+
+    :param aws_conn_id: aws connection to use.
+    :type aws_conn_id: str
+    :param sleep_time: Time to wait between two consecutive call to check query status on athena
+    :type sleep_time: int
+    """
+
+    INTERMEDIATE_STATES = ('QUEUED', 'RUNNING',)
+    FAILURE_STATES = ('FAILED', 'CANCELLED',)
+    SUCCESS_STATES = ('SUCCEEDED',)
+
+    def __init__(self, aws_conn_id='aws_default', sleep_time=30, *args, **kwargs):
+        super(AWSAthenaHook, self).__init__(aws_conn_id, *args, **kwargs)
+        self.sleep_time = sleep_time
+        self.conn = None
+        self.glue_conn = None
+        self.s3_conn = None
+
+    def get_conn(self):
+        """
+        check if aws conn exists already or create one and return it
+
+        :return: boto3 session
+        """
+        if not self.conn:
+            self.conn = self.get_client_type('athena')
+        return self.conn
+
+    def get_glue_conn(self):
+        if not self.glue_conn:
+            self.glue_conn = self.get_client_type('glue')
+        return self.glue_conn
+
+    def get_s3_conn(self):
+        if not self.s3_conn:
+            self.s3_conn = self.get_resource_type('s3')
+        return self.s3_conn
+
+    def drop_table(self, database, table):
+        try:
+            self.get_glue_conn().delete_table(DatabaseName=database, Name=table)
+        except ClientError as error:
+            if error.response['Error']['Code'] == 'EntityNotFoundException':
+                self.log.info(f"Table doesn't exist: {database}.{table}")
+            else:
+                raise error
+
+    def check_table_exists(self, database, table):
+        self.log.info(f"Checking existence of table: {database}.{table}")
+        try:
+            self.get_glue_conn().get_table(DatabaseName=database, Name=table)
+            self.log.info(f"Table: {database}.{table} exists")
+            return True
+        except ClientError as error:
+            if error.response['Error']['Code'] == 'EntityNotFoundException':
+                self.log.info(f"Table: {database}.{table} doesn't exist")
+            else:
+                raise error
+
+    def delete_s3_location(self, s3_bucket, s3_path, database, table):
+        s3 = self.get_s3_conn()
+
+        bucket = s3.Bucket(s3_bucket)
+        bucket.objects.filter(Prefix=f"{path.join(s3_path, database, table)}/").delete()
+
+    def run_query(self, query, query_context, result_configuration, client_request_token=None,
+                  workgroup='primary'):
+        """
+        Run Presto query on athena with provided config and return submitted query_execution_id
+
+        :param query: Presto query to run
+        :type query: str
+        :param query_context: Context in which query need to be run
+        :type query_context: dict
+        :param result_configuration: Dict with path to store results in and config related to encryption
+        :type result_configuration: dict
+        :param client_request_token: Unique token created by user to avoid multiple executions of same query
+        :type client_request_token: str
+        :param workgroup: Athena workgroup name, when not specified, will be 'primary'
+        :type workgroup: str
+        :return: str
+        """
+        response = self.get_conn().start_query_execution(QueryString=query,
+                                                         ClientRequestToken=client_request_token,
+                                                         QueryExecutionContext=query_context,
+                                                         ResultConfiguration=result_configuration,
+                                                         WorkGroup=workgroup)
+        query_execution_id = response['QueryExecutionId']
+        return query_execution_id
+
+    def check_query_status(self, query_execution_id):
+        """
+        Fetch the status of submitted athena query. Returns None or one of valid query states.
+
+        :param query_execution_id: Id of submitted athena query
+        :type query_execution_id: str
+        :return: str
+        """
+        response = self.get_conn().get_query_execution(QueryExecutionId=query_execution_id)
+        state = None
+        try:
+            state = response['QueryExecution']['Status']['State']
+        except Exception as ex:  # pylint: disable=broad-except
+            self.log.error('Exception while getting query state', ex)
+        finally:
+            # The error is being absorbed here and is being handled by the caller.
+            # The error is being absorbed to implement retries.
+            return state  # pylint: disable=lost-exception
+
+    def get_state_change_reason(self, query_execution_id):
+        """
+        Fetch the reason for a state change (e.g. error message). Returns None or reason string.
+
+        :param query_execution_id: Id of submitted athena query
+        :type query_execution_id: str
+        :return: str
+        """
+        response = self.get_conn().get_query_execution(QueryExecutionId=query_execution_id)
+        reason = None
+        try:
+            reason = response['QueryExecution']['Status']['StateChangeReason']
+        except Exception as ex:  # pylint: disable=broad-except
+            self.log.error('Exception while getting query state change reason', ex)
+        finally:
+            # The error is being absorbed here and is being handled by the caller.
+            # The error is being absorbed to implement retries.
+            return reason  # pylint: disable=lost-exception
+
+    def get_query_results(self, query_execution_id):
+        """
+        Fetch submitted athena query results. returns none if query is in intermediate state or
+        failed/cancelled state else dict of query output
+
+        :param query_execution_id: Id of submitted athena query
+        :type query_execution_id: str
+        :return: dict
+        """
+        query_state = self.check_query_status(query_execution_id)
+        if query_state is None:
+            self.log.error('Invalid Query state')
+            return None
+        elif query_state in self.INTERMEDIATE_STATES or query_state in self.FAILURE_STATES:
+            self.log.error('Query is in {state} state. Cannot fetch results'.format(state=query_state))
+            return None
+        return self.get_conn().get_query_results(QueryExecutionId=query_execution_id)
+
+    def poll_query_status(self, query_execution_id, max_tries=None):
+        """
+        Poll the status of submitted athena query until query state reaches final state.
+        Returns one of the final states
+
+        :param query_execution_id: Id of submitted athena query
+        :type query_execution_id: str
+        :param max_tries: Number of times to poll for query state before function exits
+        :type max_tries: int
+        :return: str
+        """
+        try_number = 1
+        final_query_state = None  # Query state when query reaches final state or max_tries reached
+        while True:
+            query_state = self.check_query_status(query_execution_id)
+            if query_state is None:
+                self.log.info('Trial {try_number}: Invalid query state. Retrying again'.format(
+                    try_number=try_number))
+            elif query_state in self.INTERMEDIATE_STATES:
+                self.log.info('Trial {try_number}: Query is still in an intermediate state - {state}'
+                              .format(try_number=try_number, state=query_state))
+            else:
+                self.log.info('Trial {try_number}: Query execution completed. Final state is {state}'
+                              .format(try_number=try_number, state=query_state))
+                final_query_state = query_state
+                break
+            if max_tries and try_number >= max_tries:  # Break loop if max_tries reached
+                final_query_state = query_state
+                break
+            try_number += 1
+            sleep(self.sleep_time)
+        return final_query_state
+
+    def stop_query(self, query_execution_id):
+        """
+        Cancel the submitted athena query
+
+        :param query_execution_id: Id of submitted athena query
+        :type query_execution_id: str
+        :return: dict
+        """
+        return self.get_conn().stop_query_execution(QueryExecutionId=query_execution_id)

--- a/dagger/dag_creator/airflow/operator_creators/athena_transform_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/athena_transform_creator.py
@@ -1,0 +1,45 @@
+from os.path import join
+
+from dagger.dag_creator.airflow.operator_creator import OperatorCreator
+from dagger.dag_creator.airflow.operators.aws_athena_operator import AWSAthenaOperator
+
+
+class AthenaTransformCreator(OperatorCreator):
+    ref_name = "athena_transform"
+
+    def __init__(self, task, dag):
+        super().__init__(task, dag)
+
+        athena_output = task._outputs[0]
+        self._output_database = athena_output.schema
+        self._output_table = athena_output.table
+
+    @staticmethod
+    def _read_sql(directory, file_path):
+        full_path = join(directory, file_path)
+
+        with open(full_path, "r") as f:
+            sql_string = f.read()
+
+        return sql_string
+
+    def _create_operator(self, **kwargs):
+        sql_string = self._read_sql(self._task.pipeline.directory, self._task.sql_file)
+
+        athena_op = AWSAthenaOperator(
+            dag=self._dag,
+            task_id=self._task.name,
+            query=sql_string,
+            aws_conn_id=self._task.aws_conn_id,
+            database=self._output_database,
+            s3_tmp_results_location=self._task.s3_tmp_results_location,
+            s3_output_location=self._task.s3_output_location,
+            output_table=self._output_table,
+            is_incremental=self._task.is_incremental,
+            partitioned_by=self._task.partitioned_by,
+            workgroup=self._task.workgroup,
+            params=self._template_parameters,
+            **kwargs,
+        )
+
+        return athena_op

--- a/dagger/dag_creator/airflow/operator_creators/athena_transform_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/athena_transform_creator.py
@@ -37,6 +37,7 @@ class AthenaTransformCreator(OperatorCreator):
             output_table=self._output_table,
             is_incremental=self._task.is_incremental,
             partitioned_by=self._task.partitioned_by,
+            output_format=self._task.output_format,
             workgroup=self._task.workgroup,
             params=self._template_parameters,
             **kwargs,

--- a/dagger/dag_creator/airflow/operator_factory.py
+++ b/dagger/dag_creator/airflow/operator_factory.py
@@ -2,6 +2,7 @@ from airflow.operators.dummy_operator import DummyOperator
 from dagger.dag_creator.airflow.operator_creator import OperatorCreator
 from dagger.dag_creator.airflow.operator_creators import (
     airflow_op_creator,
+    athena_transform_creator,
     batch_creator,
     dummy_creator,
     python_creator,

--- a/dagger/dag_creator/airflow/operators/aws_athena_operator.py
+++ b/dagger/dag_creator/airflow/operators/aws_athena_operator.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+from uuid import uuid4
+
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+from dagger.dag_creator.airflow.hooks.aws_athena_hook import AWSAthenaHook
+from os import path
+
+
+class AWSAthenaOperator(BaseOperator):
+    """
+    An operator that submit presto query to athena.
+
+    If ``do_xcom_push`` is True, the QueryExecutionID assigned to the
+    query will be pushed to an XCom when it successfuly completes.
+
+    :param query: Presto to be run on athena. (templated)
+    :type query: str
+    :param database: Database to select. (templated)
+    :type database: str
+    :param output_location: s3 path to write the query results into. (templated)
+    :type output_location: str
+    :param aws_conn_id: aws connection to use
+    :type aws_conn_id: str
+    :param sleep_time: Time to wait between two consecutive call to check query status on athena
+    :type sleep_time: int
+    :param max_tries: Number of times to poll for query state before function exits
+    :type max_triex: int
+    """
+
+    ui_color = '#44b5e2'
+    template_fields = ('query', 'database', 'output_location')
+    template_ext = ('.sql', )
+
+    @apply_defaults
+    def __init__(self, query, database, s3_tmp_results_location, s3_output_location, output_table, is_incremental, partitioned_by, aws_conn_id='aws_default', client_request_token=None,
+                 query_execution_context=None, result_configuration=None, sleep_time=30, max_tries=None,
+                 workgroup='primary',
+                 *args, **kwargs):
+        super(AWSAthenaOperator, self).__init__(*args, **kwargs)
+        self.query = query
+        self.database = database
+        self.output_location = s3_tmp_results_location
+        self.s3_output_location = s3_output_location
+        self.s3_output_bucket = s3_output_location.split('/')[2]
+        self.s3_output_path = '/'.join(s3_output_location.split('/')[3:])
+        self.output_table = output_table
+        self.is_incremental = is_incremental
+        self.partitioned_by = partitioned_by
+        self.aws_conn_id = aws_conn_id
+        self.client_request_token = client_request_token or str(uuid4())
+        self.workgroup = workgroup
+        self.query_execution_context = query_execution_context or {}
+        self.result_configuration = result_configuration or {}
+        self.sleep_time = sleep_time
+        self.max_tries = max_tries
+        self.query_execution_id = None
+        self.hook = None
+
+    def get_hook(self):
+        return AWSAthenaHook(self.aws_conn_id, self.sleep_time)
+
+    def build_insert_into_query(self):
+        return f"""\
+INSERT INTO {self.database}.{self.output_table}
+{self.query}
+                """
+
+    def build_ctas_query(self):
+        s3_table_location = path.join(self.s3_output_location, self.database, self.output_table)
+        with_parameters_dict = {
+            "external_location": f"'{s3_table_location}/'",
+            "format": "'PARQUET'"
+        }
+
+        partitioned_by_str = ','.join([f"'{column}'" for column in self.partitioned_by])
+        if self.partitioned_by:
+            with_parameters_dict['partitioned_by'] = f"ARRAY[{partitioned_by_str}]"
+
+        with_parameters_expression =\
+            ",\n    ".join([f"{parameter} = {value}" for parameter, value in with_parameters_dict.items()])
+
+        return f"""\
+CREATE TABLE {self.database}.{self.output_table}
+WITH (
+    {with_parameters_expression}
+)
+AS {self.query}
+        """
+
+    def extend_query(self, query):
+        if self.is_incremental and self.hook.check_table_exists(self.database, self.output_table):
+            return self.build_insert_into_query()
+        else:
+            return self.build_ctas_query()
+
+    def execute(self, context):
+        """
+        Run Presto Query on Athena
+        """
+        self.hook = self.get_hook()
+
+        self.log.info(f"""
+
+            is_incremental: {self.is_incremental}
+            output_database: {self.database}
+            output_table: {self.output_table}
+            s3_output_location: {self.s3_output_location}
+
+        """)
+
+        if not self.is_incremental:
+            self.log.info(f"Dropping table: {self.database}.{self.output_table}")
+            self.hook.drop_table(self.database, self.output_table)
+            self.log.info(f"Deleting s3 location: s3://{self.s3_output_bucket}/{self.s3_output_path}/{self.database}/{self.output_table}")
+            self.hook.delete_s3_location(self.s3_output_bucket, self.s3_output_path, self.database, self.output_table)
+
+        self.query_execution_context['Database'] = self.database
+        self.result_configuration['OutputLocation'] = self.output_location
+        query = self.extend_query(self.query)
+        self.log.info(f"Running query\n{query}")
+        self.query_execution_id = self.hook.run_query(query, self.query_execution_context,
+                                                      self.result_configuration, self.client_request_token,
+                                                      self.workgroup)
+        query_status = self.hook.poll_query_status(self.query_execution_id, self.max_tries)
+
+        if query_status in AWSAthenaHook.FAILURE_STATES:
+            error_message = self.hook.get_state_change_reason(self.query_execution_id)
+            raise Exception(
+                'Final state of Athena job is {}, query_execution_id is {}. Error: {}'
+                .format(query_status, self.query_execution_id, error_message))
+        elif not query_status or query_status in AWSAthenaHook.INTERMEDIATE_STATES:
+            raise Exception(
+                'Final state of Athena job is {}. '
+                'Max tries of poll status exceeded, query_execution_id is {}.'
+                .format(query_status, self.query_execution_id))
+
+        return self.query_execution_id
+
+    def on_kill(self):
+        """
+        Cancel the submitted athena query
+        """
+        if self.query_execution_id:
+            self.log.info('⚰️⚰️⚰️ Received a kill Signal. Time to Die')
+            self.log.info(
+                'Stopping Query with executionId - %s', self.query_execution_id
+            )
+            response = self.hook.stop_query(self.query_execution_id)
+            http_status_code = None
+            try:
+                http_status_code = response['ResponseMetadata']['HTTPStatusCode']
+            except Exception as ex:
+                self.log.error('Exception while cancelling query', ex)
+            finally:
+                if http_status_code is None or http_status_code != 200:
+                    self.log.error('Unable to request query cancel on athena. Exiting')
+                else:
+                    self.log.info(
+                        'Polling Athena for query with id %s to reach final state', self.query_execution_id
+                    )
+                    self.hook.poll_query_status(self.query_execution_id)

--- a/dagger/dagger_config.yaml
+++ b/dagger/dagger_config.yaml
@@ -37,6 +37,7 @@ athena:
 #  default_s3_output_location:
 #  s3_tmp_results_location:
 #  default_workgroup:
+#  default_output_format:
 
 
 sqoop:

--- a/dagger/dagger_config.yaml
+++ b/dagger/dagger_config.yaml
@@ -32,6 +32,12 @@ batch:
 #  default_queue:
 #  cluster_name:
 
+athena:
+#  aws_conn_id:
+#  default_s3_output_location:
+#  s3_tmp_results_location:
+#  default_workgroup:
+
 
 sqoop:
 #  default_files_format: avro

--- a/dagger/pipeline/io_factory.py
+++ b/dagger/pipeline/io_factory.py
@@ -1,6 +1,13 @@
 from dagger.pipeline.io import IO
 from os import path
-from dagger.pipeline.ios import db_io, dummy_io, gdrive_io, redshift_io, s3_io
+from dagger.pipeline.ios import (
+    athena_io,
+    db_io,
+    dummy_io,
+    gdrive_io,
+    redshift_io,
+    s3_io
+)
 
 
 class IOFactory:

--- a/dagger/pipeline/ios/athena_io.py
+++ b/dagger/pipeline/ios/athena_io.py
@@ -1,0 +1,42 @@
+from dagger.pipeline.io import IO
+from dagger.utilities.config_validator import Attribute
+
+
+class AthenaIO(IO):
+    ref_name = "athena"
+
+    @classmethod
+    def init_attributes(cls, orig_cls):
+        cls.add_config_attributes(
+            [
+                Attribute(
+                    attribute_name="schema", comment="Leave it empty for system tables"
+                ),
+                Attribute(attribute_name="table"),
+            ]
+        )
+
+    def __init__(self, io_config, config_location):
+        super().__init__(io_config, config_location)
+
+        self._schema = self.parse_attribute("schema")
+        self._table = self.parse_attribute("table")
+
+    def alias(self):
+        return "athena://{}/{}".format(self._schema, self._table)
+
+    @property
+    def rendered_name(self):
+        return "{}.{}".format(self._schema, self._table)
+
+    @property
+    def airflow_name(self):
+        return "athena-{}-{}".format(self._schema, self._table)
+
+    @property
+    def schema(self):
+        return self._schema
+
+    @property
+    def table(self):
+        return self._table

--- a/dagger/pipeline/task_factory.py
+++ b/dagger/pipeline/task_factory.py
@@ -1,6 +1,7 @@
 from dagger.pipeline.task import Task
 from dagger.pipeline.tasks import (
     airflow_op_task,
+    athena_transform_task,
     batch_task,
     python_task,
     redshift_load_task,

--- a/dagger/pipeline/tasks/athena_transform_task.py
+++ b/dagger/pipeline/tasks/athena_transform_task.py
@@ -1,0 +1,95 @@
+from dagger import conf
+from dagger.pipeline.task import Task
+from dagger.utilities.config_validator import Attribute
+
+
+class AthenaTransformTask(Task):
+    ref_name = "athena_transform"
+
+    @classmethod
+    def init_attributes(cls, orig_cls):
+        cls.add_config_attributes(
+            [
+                Attribute(
+                    attribute_name="sql",
+                    parent_fields=["task_parameters"],
+                    comment="Relative path to sql file",
+                ),
+                Attribute(
+                    attribute_name="aws_conn_id",
+                    required=False,
+                    parent_fields=["task_parameters"],
+                ),
+                Attribute(
+                    attribute_name="s3_tmp_results_location",
+                    required=False,
+                    parent_fields=["task_parameters"],
+                ),
+                Attribute(
+                    attribute_name="s3_output_location",
+                    required=False,
+                    parent_fields=["task_parameters"],
+                ),
+                Attribute(
+                    attribute_name="workgroup",
+                    required=False,
+                    parent_fields=["task_parameters"],
+                ),
+                Attribute(
+                    attribute_name="is_incremental",
+                    required=True,
+                    validator=bool,
+                    comment="""If set yes then SQL going to be an INSERT INTO\
+                               statement, otherwise a DROP TABLE; CTAS statement""",
+                    parent_fields=["task_parameters"],
+                ),
+                Attribute(
+                    attribute_name="partitioned_by",
+                    required=False,
+                    validator=list,
+                    comment="The list of fields to partition by. These fields should come last in the select statement",
+                    parent_fields=["task_parameters"],
+                ),
+            ]
+        )
+
+    def __init__(self, name, pipeline_name, pipeline, job_config):
+        super().__init__(name, pipeline_name, pipeline, job_config)
+
+        self._sql_file = self.parse_attribute("sql")
+        self._aws_conn_id = (
+            self.parse_attribute("aws_conn_id") or conf.ATHENA_AWS_CONN_ID
+        )
+        self._s3_tmp_results_location = self.parse_attribute("s3_tmp_results_location") or conf.ATHENA_S3_TMP_RESULTS_LOCATION
+        self._s3_output_location = self.parse_attribute("s3_output_location") or conf.ATHENA_DEFAULT_S3_OUTPUT_LOCATION
+        self._workgroup = self.parse_attribute("workgroup") or conf.ATHENA_DEFAULT_WORKGROUP
+        self._is_incremental = self.parse_attribute("is_incremental")
+        self._partitioned_by = self.parse_attribute("partitioned_by")
+
+    @property
+    def sql_file(self):
+        return self._sql_file
+
+    @property
+    def aws_conn_id(self):
+        return self._aws_conn_id
+
+    @property
+    def s3_tmp_results_location(self):
+        return self._s3_tmp_results_location
+
+    @property
+    def s3_output_location(self):
+        return self._s3_output_location
+
+    @property
+    def workgroup(self):
+        return self._workgroup
+
+    @property
+    def is_incremental(self):
+        return self._is_incremental
+
+    @property
+    def partitioned_by(self):
+        return self._partitioned_by

--- a/dagger/pipeline/tasks/athena_transform_task.py
+++ b/dagger/pipeline/tasks/athena_transform_task.py
@@ -50,6 +50,13 @@ class AthenaTransformTask(Task):
                     comment="The list of fields to partition by. These fields should come last in the select statement",
                     parent_fields=["task_parameters"],
                 ),
+                Attribute(
+                    attribute_name="output_format",
+                    required=False,
+                    validator=str,
+                    comment="Output file format. One of PARQUET/ORC/JSON/CSV",
+                    parent_fields=["task_parameters"],
+                )
             ]
         )
 
@@ -65,6 +72,7 @@ class AthenaTransformTask(Task):
         self._workgroup = self.parse_attribute("workgroup") or conf.ATHENA_DEFAULT_WORKGROUP
         self._is_incremental = self.parse_attribute("is_incremental")
         self._partitioned_by = self.parse_attribute("partitioned_by")
+        self._output_format = self.parse_attribute("output_format")
 
     @property
     def sql_file(self):
@@ -93,3 +101,7 @@ class AthenaTransformTask(Task):
     @property
     def partitioned_by(self):
         return self._partitioned_by
+
+    @property
+    def output_format(self):
+        return self._output_format

--- a/tests/fixtures/pipeline/ios/athena_io.yaml
+++ b/tests/fixtures/pipeline/ios/athena_io.yaml
@@ -1,0 +1,10 @@
+type: athena
+name: test
+schema: test_schema                       # Leave it empty for system tables
+table: test_table
+
+
+
+# Other attributes:
+
+# has_dependency:                # Weather this i/o should be added to the dependency graph or not. Default is True

--- a/tests/pipeline/ios/test_athena_io.py
+++ b/tests/pipeline/ios/test_athena_io.py
@@ -1,0 +1,17 @@
+import unittest
+from dagger.pipeline.io_factory import athena_io
+
+import yaml
+
+
+class DbIOTest(unittest.TestCase):
+    def setUp(self) -> None:
+        with open('tests/fixtures/pipeline/ios/athena_io.yaml', "r") as stream:
+            config = yaml.safe_load(stream)
+
+        self.db_io = athena_io.AthenaIO(config, "/")
+
+    def test_properties(self):
+        self.assertEqual(self.db_io.alias(), "athena://test_schema/test_table")
+        self.assertEqual(self.db_io.rendered_name, "test_schema.test_table")
+        self.assertEqual(self.db_io.airflow_name, "athena-test_schema-test_table")


### PR DESCRIPTION
1. Create custom athena operator. Differences from the already existing version:
- Based on _is_incremental attribute it automatically adds CREATE TABLE AS or INSERT INTO header for query
- In case of CTAS it deletes output table from glue and already existing s3 data, so the query won't fail when running for the second time.
- It allows to pass partition by and other attributes (more flexible)
2. Adding io type: Athena
3. Adding Athena task
4. Adding tests