### PR TITLE
Removing spark params; Adding -- prefix to other params; setting temp…

### DIFF
--- a/dagger/dag_creator/airflow/operator_creators/spark_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/spark_creator.py
@@ -91,8 +91,9 @@ class SparkCreator(OperatorCreator):
                 **kwargs,
             )
         elif self._task.spark_engine == "glue":
-            parameters = self._template_parameters
-            parameters.update(self._task.spark_args)
+            parameters = {
+                f"--{parameter}": value for parameter, value in self._template_parameters.items()
+            }
 
             spark_op = AwsGlueJobOperator(
                 dag=self._dag,

--- a/dagger/dag_creator/airflow/operators/aws_glue_job_operator.py
+++ b/dagger/dag_creator/airflow/operators/aws_glue_job_operator.py
@@ -46,7 +46,7 @@ class AwsGlueJobOperator(BaseOperator):
     :type region_name: str
     """
 
-    template_fields = ()
+    template_fields = ("script_args",)
     template_ext = ()
     ui_color = '#ededed'
 


### PR DESCRIPTION
…late params to seeable on UI

1. Removing spark configs because glue is settting the optimal ones based on DPU number
2. Adding the -- prefix for job parameters
3. Adding the arguments as template params in glue operator, so they are visible on the UI