### PR TITLE
Using the base operator for all custom operators

### DIFF
--- a/dagger/dag_creator/airflow/operators/aws_athena_operator.py
+++ b/dagger/dag_creator/airflow/operators/aws_athena_operator.py
@@ -20,13 +20,13 @@
 
 from uuid import uuid4
 
-from airflow.models import BaseOperator
+from dagger.dag_creator.airflow.operators.dagger_base_operator import DaggerBaseOperator
 from airflow.utils.decorators import apply_defaults
 from dagger.dag_creator.airflow.hooks.aws_athena_hook import AWSAthenaHook
 from os import path
 
 
-class AWSAthenaOperator(BaseOperator):
+class AWSAthenaOperator(DaggerBaseOperator):
     """
     An operator that submit presto query to athena.
 

--- a/dagger/dag_creator/airflow/operators/aws_glue_job_operator.py
+++ b/dagger/dag_creator/airflow/operators/aws_glue_job_operator.py
@@ -16,11 +16,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import os.path
 from typing import Optional
 
-from airflow.models import BaseOperator
-from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from dagger.dag_creator.airflow.operators.dagger_base_operator import DaggerBaseOperator
 from airflow.utils.decorators import apply_defaults
 from airflow.contrib.hooks.aws_hook import AwsHook
 from airflow.exceptions import AirflowException
@@ -32,7 +30,7 @@ OUTPUT_LOG_GROUP = "/aws-glue/jobs/output"
 ERROR_LOG_GROUP = "/aws-glue/jobs/error"
 
 
-class AwsGlueJobOperator(BaseOperator):
+class AwsGlueJobOperator(DaggerBaseOperator):
     """
     Creates an AWS Glue Job. AWS Glue is a serverless Spark
     ETL service for running Spark Jobs on the AWS cloud.


### PR DESCRIPTION
Using the base operator eliminates the warning about unused keywords when creating new operators, since the DaggerBaseOperator is swallowing this parameter and not proxying it to airflow's BaseOperator