### PR TITLE
Fixing first run problem

### DIFF
--- a/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
@@ -83,7 +83,7 @@ class RedshiftLoadCreator(OperatorCreator):
 
         return \
             f"BEGIN TRANSACTION;\n" \
-            f"DROP TABLE {self._output_schema_quoted}.{self._output_table_quoted};\n" \
+            f"DROP TABLE IF EXISTS {self._output_schema_quoted}.{self._output_table_quoted};\n" \
             f"ALTER TABLE {self._output_schema_quoted}.{self._tmp_table_quoted} " \
             f"RENAME TO {self._output_table_quoted};\n" \
             f"END"


### PR DESCRIPTION
If it's a first run and target table not exists than replace command was failing