### PR TITLE
Handling when there is no end time for task when fails

### DIFF
--- a/dagger/alerts/alert.py
+++ b/dagger/alerts/alert.py
@@ -104,7 +104,11 @@ def airflow_task_fail_alerts(alerts: List[AlertBase], context):
         return
 
     task_instance = context["task_instance"]
-    run_time = (task_instance.end_date - task_instance.start_date).total_seconds()
+    try:
+        run_time = (task_instance.end_date - task_instance.start_date).total_seconds()
+    except TypeError as e:
+        logging
+        run_time = 0
 
     for alert in alerts:
         alert.execute(


### PR DESCRIPTION
In rare cases airflow task fails without even starting the task and having a task run object in db. In these cases end_time doesn't exist for the task_instance object