### PR TITLE
Graph edges

### DIFF
--- a/dagger/dag_creator/airflow/dag_creator.py
+++ b/dagger/dag_creator/airflow/dag_creator.py
@@ -118,10 +118,13 @@ class DagCreator(GraphTraverserBase):
             else None
         )
         for to_task_id in to_task_ids:
+            edge_properties = self._task_graph.get_edge(node.obj.alias(), to_task_id)
+            print('XXX get edge', node.obj.alias(), to_task_id, edge_properties.follow_external_dependency)
             to_pipe = self._task_graph.get_node(to_task_id).obj.pipeline_name
             if from_pipe and from_pipe == to_pipe:
                 self._tasks[from_task_id] >> self._tasks[to_task_id]
-            elif from_pipe and from_pipe != to_pipe and node.obj.follow_external_dependency:
+            elif from_pipe and from_pipe != to_pipe and edge_properties.follow_external_dependency:
+                print('XXX Adding external_sensor', from_task_id, to_task_id)
                 from_schedule = self._task_graph.get_node(from_task_id).obj.pipeline.schedule
                 to_schedule = self._task_graph.get_node(to_task_id).obj.pipeline.schedule
                 if not from_schedule.startswith('@') and not to_schedule.startswith('@'):

--- a/dagger/graph/task_graph.py
+++ b/dagger/graph/task_graph.py
@@ -78,8 +78,7 @@ class Graph(object):
         node_type: str,
         node_id: str,
         name_to_show: str = None,
-        obj: object = None,
-        update: bool = False,
+        obj: object = None
     ):
         if self._nodes.get(node_type, None) is None:
             self._nodes[node_type] = {}
@@ -91,14 +90,12 @@ class Graph(object):
             )
             raise IdAlreadyExistsException(f"A different type of node with the same id: {node_id} already exists")
 
-        if self._nodes[node_type].get(node_id) and not update:
+        if self._nodes[node_type].get(node_id):
             _logger.debug("Node with name: %s already exists", node_id)
             return
-        elif self._nodes[node_type].get(node_id) and update:
-            self._nodes[node_type][node_id].obj.update(obj)
-        else:
-            self._node2type[node_id] = node_type
-            self._nodes[node_type][node_id] = Node(node_id, name_to_show, obj)
+
+        self._node2type[node_id] = node_type
+        self._nodes[node_type][node_id] = Node(node_id, name_to_show, obj)
 
     def get_node(self, node_id: str):
         if not self._node_exists(node_id):
@@ -184,9 +181,7 @@ class TaskGraph:
                 self._graph.add_edge(task.uniq_name, task_output.alias())
 
     def add_dataset(self, io: IO):
-        self._graph.add_node(
-            node_type=self.NODE_TYPE_DATASET, node_id=io.alias(), obj=io, update=True
-        )
+        self._graph.add_node(node_type=self.NODE_TYPE_DATASET, node_id=io.alias(), obj=io)
 
     def print_graph(self, out_file=None):
         fs = open(out_file, "w") if out_file else sys.stdout

--- a/dagger/graph/task_graph.py
+++ b/dagger/graph/task_graph.py
@@ -6,6 +6,7 @@ import dagger.pipeline.pipeline
 from dagger.pipeline.io import IO
 from dagger.pipeline.task import Task
 from dagger.utilities.exceptions import IdAlreadyExistsException
+from dagger.conf import config
 
 _logger = logging.getLogger("graph")
 
@@ -16,7 +17,6 @@ class Node(ABC):
         self._name = name_to_show if name_to_show else node_id
         self._parents = set()
         self._children = set()
-        self._attributes = {}
 
         self._obj = obj
 
@@ -44,15 +44,6 @@ class Node(ABC):
         return self._children
 
     @property
-    def attributes(self):
-        return self._attributes
-
-    @attributes.setter
-    def attributes(self, t_key_value):
-        key, value = t_key_value
-        self._attributes[key] = value
-
-    @property
     def obj(self):
         return self._obj
 
@@ -63,10 +54,21 @@ class Node(ABC):
         self._children.add(child_id)
 
 
+class Edge:
+    def __init__(self, follow_external_dependency=False):
+        print('XXX Creating edge with: ', follow_external_dependency)
+        self._follow_external_dependency = follow_external_dependency
+
+    @property
+    def follow_external_dependency(self):
+        return self._follow_external_dependency
+
+
 class Graph(object):
     def __init__(self):
         self._nodes = {}
         self._node2type = {}
+        self._edges = {}
 
     def _node_exists(self, node_id):
         return self._node2type.get(node_id, None) is not None
@@ -107,7 +109,8 @@ class Graph(object):
     def get_nodes(self, node_type):
         return self._nodes.get(node_type, None)
 
-    def add_edge(self, from_node_id, to_node_id):
+    def add_edge(self, from_node_id, to_node_id, **attributes):
+        print('XXX add edge', from_node_id, to_node_id, attributes)
         from_node = self.get_node(from_node_id)
         to_node = self.get_node(to_node_id)
 
@@ -129,12 +132,16 @@ class Graph(object):
 
         from_node.add_child(to_node_id)
         to_node.add_parent(from_node_id)
+        self._edges[(from_node_id, to_node_id)] = Edge(**attributes)
 
     def get_type(self, node_id):
         if not self._node_exists(node_id):
             return None
 
         return self._node2type[node_id]
+
+    def get_edge(self, from_node_id, to_node_id):
+        return self._edges.get((from_node_id, to_node_id))
 
 
 class TaskGraph:
@@ -165,7 +172,11 @@ class TaskGraph:
         for task_input in task.inputs:
             self.add_dataset(task_input)
             if task_input.has_dependency:
-                self._graph.add_edge(task_input.alias(), task.uniq_name)
+                self._graph.add_edge(
+                    task_input.alias(),
+                    task.uniq_name,
+                    follow_external_dependency=task_input.follow_external_dependency
+                )
 
         for task_output in task.outputs:
             self.add_dataset(task_output)

--- a/dagger/pipeline/io.py
+++ b/dagger/pipeline/io.py
@@ -39,10 +39,6 @@ class IO(ConfigValidator, ABC):
     def __eq__(self, other):
         return self.alias() == other.alias()
 
-    def update(self, other_io):
-        self._has_dependency = self._has_dependency or other_io.has_dependency
-        self._follow_external_dependency = self._follow_external_dependency or other_io.follow_external_dependency
-
     @abstractmethod
     def alias(self):
         pass

--- a/dagger/pipeline/task.py
+++ b/dagger/pipeline/task.py
@@ -1,6 +1,7 @@
 import logging
 import re
 import datetime
+from typing import List
 
 from os.path import join
 
@@ -102,23 +103,23 @@ class Task(ConfigValidator):
         return self._pipeline
 
     @property
-    def uniq_name(self):
+    def uniq_name(self) -> str:
         return "{}:{}".format(self.name, self.pipeline_name)
 
     @property
-    def airflow_parameters(self):
+    def airflow_parameters(self) -> dict:
         return self._airflow_parameters
 
     @property
-    def template_parameters(self):
+    def template_parameters(self) -> dict:
         return self._template_parameters
 
     @property
-    def inputs(self):
+    def inputs(self) -> List[IO]:
         return self._inputs
 
     @property
-    def outputs(self):
+    def outputs(self) -> List[IO]:
         return self._outputs
 
     @property

--- a/tests/graph/test_task_graph.py
+++ b/tests/graph/test_task_graph.py
@@ -45,9 +45,6 @@ class TestGraph(unittest.TestCase):
         graph.add_node("type1", "id1", "name2")
         self.assertEqual(graph.get_node("id1")._name, "name1")
 
-        #graph.add_node("type1", "id1", "name2", update=True)
-        #self.assertEqual(graph.get_node("id1")._name, "name2")
-
     def test_add_edge(self):
         graph = task_graph.Graph()
         graph.add_node("type1", "id1")


### PR DESCRIPTION
Added the concept edge to the task graph, so we can store dataset -> job related attributes in the task graph. E.g.: follow_external_dependency

This fixes the issue of storing this parameter on the data node itself, which can cause problems if more then one task is depending on the same dataset.