### PR TITLE
only create Pipeline object if pipe is not disabled

### DIFF
--- a/dagger/config_finder/config_processor.py
+++ b/dagger/config_finder/config_processor.py
@@ -48,6 +48,7 @@ class ConfigProcessor:
             if config_dict:
                 pipeline = Pipeline(pipeline_config.directory, config_dict)
             else:
+                _logger.info(f"{pipeline_name} pipeline is disabled in {conf.ENV} environment")
                 continue
 
             for task_config in pipeline_config.job_configs:


### PR DESCRIPTION
Fixing the dag import issue on staging. The disable param previously only worked for individual tasks, now it also works for entire pipelines.