### PR TITLE
Feature/adjust spark ssm timeout

### DIFF
--- a/dagger/dag_creator/airflow/operator_creator.py
+++ b/dagger/dag_creator/airflow/operator_creator.py
@@ -27,12 +27,16 @@ class OperatorCreator(ABC):
 
     def _update_airflow_parameters(self):
         self._airflow_parameters.update(self._task.airflow_parameters)
-        self._fix_timedelta_parameters()
 
         self._airflow_parameters.update({"description": self._task.description})
 
         if self._task.pool:
             self._airflow_parameters["pool"] = self._task.pool
+
+        if self._task.timeout_in_seconds:
+            self._airflow_parameters["execution_timeout"] = self._task.timeout_in_seconds
+
+        self._fix_timedelta_parameters()
 
     def create_operator(self):
         self._template_parameters.update(self._task.template_parameters)

--- a/dagger/dag_creator/airflow/operator_creator.py
+++ b/dagger/dag_creator/airflow/operator_creator.py
@@ -1,4 +1,7 @@
 from abc import ABC, abstractmethod
+from datetime import timedelta
+
+TIMEDELTA_PARAMETERS = ['execution_timeout']
 
 
 class OperatorCreator(ABC):
@@ -16,8 +19,15 @@ class OperatorCreator(ABC):
         for io in ios:
             self._template_parameters[io.name] = io.rendered_name
 
+    def _fix_timedelta_parameters(self):
+        for timedelta_parameter in TIMEDELTA_PARAMETERS:
+            if self._airflow_parameters.get(timedelta_parameter) is not None:
+                self._airflow_parameters[timedelta_parameter] =\
+                    timedelta(seconds=self._airflow_parameters[timedelta_parameter])
+
     def _update_airflow_parameters(self):
         self._airflow_parameters.update(self._task.airflow_parameters)
+        self._fix_timedelta_parameters()
 
         self._airflow_parameters.update({"description": self._task.description})
 

--- a/dagger/dag_creator/airflow/operators/spark_submit_operator.py
+++ b/dagger/dag_creator/airflow/operators/spark_submit_operator.py
@@ -64,8 +64,7 @@ class SparkSubmitOperator(DaggerBaseOperator):
             spark_submit_cmd += " " + self.job_args
         return spark_submit_cmd
 
-    @property
-    def execution_timeout(self):
+    def get_execution_timeout(self):
         if self._execution_timeout:
             return self._execution_timeout.seconds
 
@@ -99,7 +98,7 @@ class SparkSubmitOperator(DaggerBaseOperator):
             "InstanceIds": [emr_master_instance_id],
             "DocumentName": "AWS-RunShellScript",
             "Parameters": {"commands": [self.spark_submit_cmd]},
-            "TimeoutSeconds": self.execution_timeout
+            "TimeoutSeconds": self.get_execution_timeout()
 
         }
         response = self.ssm_client.send_command(

--- a/dagger/dag_creator/airflow/operators/spark_submit_operator.py
+++ b/dagger/dag_creator/airflow/operators/spark_submit_operator.py
@@ -36,6 +36,7 @@ class SparkSubmitOperator(DaggerBaseOperator):
         self.spark_conf_args = spark_conf_args
         self.extra_py_files = extra_py_files
         self.cluster_name = cluster_name
+        self._execution_timeout = kwargs.get('execution_timeout')
 
     @property
     def emr_client(self):
@@ -63,6 +64,13 @@ class SparkSubmitOperator(DaggerBaseOperator):
             spark_submit_cmd += " " + self.job_args
         return spark_submit_cmd
 
+    @property
+    def execution_timeout(self):
+        if self._execution_timeout:
+            return self._execution_timeout.seconds
+
+        return None
+
     def get_cluster_id_by_name(self, emr_cluster_name, cluster_states):
 
         response = self.emr_client.list_clusters(ClusterStates=cluster_states)
@@ -86,10 +94,16 @@ class SparkSubmitOperator(DaggerBaseOperator):
         emr_master_instance_id = self.emr_client.list_instances(ClusterId=cluster_id, InstanceGroupTypes=["MASTER"],
                                                                 InstanceStates=["RUNNING"])["Instances"][0][
             "Ec2InstanceId"]
+
+        send_command_params = {
+            "InstanceIds": [emr_master_instance_id],
+            "DocumentName": "AWS-RunShellScript",
+            "Parameters": {"commands": [self.spark_submit_cmd]},
+            "TimeoutSeconds": self.execution_timeout
+
+        }
         response = self.ssm_client.send_command(
-            InstanceIds=[emr_master_instance_id],
-            DocumentName="AWS-RunShellScript",
-            Parameters={"commands": [self.spark_submit_cmd]},
+            **{key: value for key, value in send_command_params.items() if value is not None}
         )
         command_id = response['Command']['CommandId']
         status = 'Pending'

--- a/dagger/pipeline/task.py
+++ b/dagger/pipeline/task.py
@@ -37,6 +37,11 @@ class Task(ConfigValidator):
                 ),
                 Attribute(attribute_name="pool", required=False),
                 Attribute(
+                    attribute_name="timeout_in_seconds",
+                    required=False,
+                    format_help="int",
+                    validator=int),
+                Attribute(
                     attribute_name="airflow_task_parameters",
                     nullable=True,
                     format_help="dictionary",
@@ -67,6 +72,7 @@ class Task(ConfigValidator):
         self._inputs = []
         self._outputs = []
         self._pool = self.parse_attribute("pool") or self.default_pool
+        self._timeout_in_seconds = self.parse_attribute("timeout_in_seconds")
         self.process_inputs(config["inputs"])
         self.process_outputs(config["outputs"])
 
@@ -126,6 +132,10 @@ class Task(ConfigValidator):
     @property
     def pool(self):
         return self._pool
+
+    @property
+    def timeout_in_seconds(self):
+        return self._timeout_in_seconds
 
     def add_input(self, task_input: IO):
         _logger.info("Adding input: %s to task: %s", task_input.name, self._name)

--- a/tests/fixtures/config_finder/root/dags/test_spark/spark.yaml
+++ b/tests/fixtures/config_finder/root/dags/test_spark/spark.yaml
@@ -28,6 +28,7 @@ task_parameters:
   job_args:
       param1: test
 pool: emr
+timeout_in_seconds: 7200
 
 environments:
   local:


### PR DESCRIPTION
Description:
Currently if spark jobs sent via SSM to EMR are taking longer then 1 hour than SSM times out which results in airflow thinking the job has failed. 

Solution:
Airflow already have an execution_timeout task parameter that so far we couldn't use because it needs to be in timedelta format, however we cannot pass timedelta type from yaml configurations.
1. When creating airflow operators then we are converting all task parameters which needs to be in timedelta format to timedelta in seconds
2. In the emr spark submit operator we take the execution_timeout parameter and pass it along to the ssm send_command if the parameter is not none.