### PR TITLE
Update operator_creator.py

### DIFF
--- a/dagger/dag_creator/airflow/operator_creator.py
+++ b/dagger/dag_creator/airflow/operator_creator.py
@@ -30,6 +30,8 @@ class OperatorCreator(ABC):
 
         self._airflow_parameters.update({"description": self._task.description})
 
+        self._airflow_parameters.update({"task_concurrency": 1})
+
         if self._task.pool:
             self._airflow_parameters["pool"] = self._task.pool
 


### PR DESCRIPTION
https://choco.atlassian.net/browse/DATA-914

The Airflow Base Operator has a parameter called task_concurrency, which if it's set to 1 it won't allow two concurrent runs of the same task. (Note that the depends_on_past=True would also be sufficient unless a previous task is manually cleared)

https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/baseoperator/index.html?highlight=task_concurrency