### PR TITLE
Add verbose logging option to dbt operator

### DIFF
--- a/dagger/dag_creator/airflow/operator_creators/dbt_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/dbt_creator.py
@@ -12,6 +12,7 @@ class DbtCreator(OperatorCreator):
         self._profile_dir = task.profile_dir
         self._profile_name = task.profile_name
         self._select = task.select
+        self._verbose = tasl.verbose
 
     def _generate_deps_command(self):
         command = [
@@ -24,7 +25,9 @@ class DbtCreator(OperatorCreator):
 
     def _generate_build_command(self):
         command = [
-            "dbt build",
+            "dbt",
+            "--debug" if self._verbose else "",
+            "build",
             f"--project-dir {self._project_dir}",
             f"--profiles-dir {self._profile_dir}",
             f"--target {self._profile_name}",

--- a/dagger/dag_creator/airflow/operator_creators/dbt_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/dbt_creator.py
@@ -12,7 +12,7 @@ class DbtCreator(OperatorCreator):
         self._profile_dir = task.profile_dir
         self._profile_name = task.profile_name
         self._select = task.select
-        self._verbose = tasl.verbose
+        self._verbose = task.verbose
 
     def _generate_deps_command(self):
         command = [

--- a/dagger/pipeline/tasks/dbt_task.py
+++ b/dagger/pipeline/tasks/dbt_task.py
@@ -31,6 +31,12 @@ class DbtTask(Task):
                     parent_fields=["task_parameters"],
                     comment="Passed into dbt --select",
                 ),
+                Attribute(
+                    attribute_name="verbose",
+                    required=False,
+                    parent_fields=["task_parameters"],
+                    comment="Verbose debug level dbt logging",
+                ),
             ]
         )
 
@@ -41,6 +47,7 @@ class DbtTask(Task):
         self._profile_dir = self.parse_attribute("profile_dir")
         self._profile_name = self.parse_attribute("profile_name") or 'default'
         self._select = self.parse_attribute("select")
+        self._verbose = self.parse_attribute("verbose") or false
 
     @property
     def project_dir(self):
@@ -57,3 +64,7 @@ class DbtTask(Task):
     @property
     def select(self):
         return self._select
+    
+    @property
+    def verbose(self):
+        return self._verbose


### PR DESCRIPTION
adding the `--debug` flag as an option to the dagger dbt operator. The flag is different from other flags in that it has to be added right after the `dbt` command, as in `dbt --debug run [...]`. 
Tested invocation with double space, in case `verbose` is set to `false`, which works as well!