### PR TITLE
fix/Disable strict_mode for envyaml

### DIFF
--- a/dagger/conf.py
+++ b/dagger/conf.py
@@ -9,7 +9,7 @@ from pathlib import Path
 AIRFLOW_HOME = os.environ.get("AIRFLOW_HOME", "/usr/local/airflow/")
 config_file = Path(AIRFLOW_HOME) / "dagger_config.yaml"
 if config_file.is_file():
-    config = EnvYAML(config_file)
+    config = EnvYAML(config_file, strict=False)
 else:
     config = {}
 


### PR DESCRIPTION
The major upgrade of envyaml introduced a new behaviour, where [strict_mode is set to `True` by default](https://github.com/thesimj/envyaml#strict-mode). This is explicitly disabling it in the `conf.py` to allow importing of `from dagger import conf`, when environment variables are not set yet (as is the case when using templates).