### PR TITLE
Fix/fixing athena transform partition by

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @siklosid
+* @chocoapp/data-engineering

--- a/dagger/dag_creator/airflow/operators/aws_athena_operator.py
+++ b/dagger/dag_creator/airflow/operators/aws_athena_operator.py
@@ -95,7 +95,7 @@ INSERT INTO {self.database}.{self.output_table}
         }
 
         if self.partitioned_by:
-            partitioned_by_str = ','.join([f"'{column}'" for column in self.partitioned_by])
+            partitioned_by_str = ','.join([f"'{column}'" for column in self.partitioned_by.split(',')])
             with_parameters_dict['partitioned_by'] = f"ARRAY[{partitioned_by_str}]"
 
         if self.output_format:


### PR DESCRIPTION
Atm if we use the partitioned by attribute of athena transform, it will split the string on each character to get partition columns. Instead we need to split based on commas to get the proper result