### PR TITLE
Feature/redshift load alter infered columns

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @siklosid
+* @chocoapp/data-engineering

--- a/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
@@ -2,7 +2,7 @@ from os.path import join
 from typing import Optional
 
 from dagger.dag_creator.airflow.operator_creator import OperatorCreator
-from dagger.dag_creator.airflow.operators.postgres_operator import PostgresOperator
+from dagger.dag_creator.airflow.operators.redshift_sql_operator import RedshiftSQLOperator
 
 
 class RedshiftLoadCreator(OperatorCreator):
@@ -85,7 +85,7 @@ class RedshiftLoadCreator(OperatorCreator):
         )
 
         return f"copy {self._output_schema_quoted}.{table_name}{columns}\n" \
-               f"from '{self._input_path}'\n" \
+               f"from 's3://chodatastg-data-lake/dwh/salesforce/task/task'\n" \
                f"iam_role '{self._task.iam_role}'\n" \
                f"{extra_parameters}"
 
@@ -132,14 +132,13 @@ class RedshiftLoadCreator(OperatorCreator):
     def _create_operator(self, **kwargs):
         load_cmd = self._get_cmd()
 
-        redshift_op = PostgresOperator(
+        redshift_op = RedshiftSQLOperator(
             dag=self._dag,
             task_id=self._task.name,
             sql=load_cmd,
-            postgres_conn_id=self._task.postgres_conn_id,
-            params=self._template_parameters,
+            redshift_conn_id=self._task.postgres_conn_id,
+            split_parameters=True,
             autocommit=True,
-            **kwargs,
+            **kwargs
         )
-
         return redshift_op

--- a/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
@@ -104,7 +104,7 @@ class RedshiftLoadCreator(OperatorCreator):
         if self._alter_columns is None:
             return None
 
-        alter_column_commands = []
+        alter_column_commands = ["set autocommit on"]
         alter_columns = self._alter_columns.split(",")
         for alter_column in alter_columns:
             [column_name, column_type] = alter_column.split(":")
@@ -112,6 +112,7 @@ class RedshiftLoadCreator(OperatorCreator):
                 f"ALTER TABLE {self._output_schema_quoted}.{self._tmp_table_quoted} "
                 f"ALTER COLUMN {column_name} TYPE {column_type}"
             )
+        alter_column_commands.append("set autocommit off")
 
         return ";\n".join(alter_column_commands)
 

--- a/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
@@ -85,7 +85,7 @@ class RedshiftLoadCreator(OperatorCreator):
         )
 
         return f"copy {self._output_schema_quoted}.{table_name}{columns}\n" \
-               f"from 's3://chodatastg-data-lake/dwh/salesforce/task/task'\n" \
+               f"from '{self._input_path}'\n" \
                f"iam_role '{self._task.iam_role}'\n" \
                f"{extra_parameters}"
 

--- a/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
@@ -104,7 +104,7 @@ class RedshiftLoadCreator(OperatorCreator):
         if self._alter_columns is None:
             return None
 
-        alter_column_commands = ["set autocommit=on"]
+        alter_column_commands = []
         alter_columns = self._alter_columns.split(",")
         for alter_column in alter_columns:
             [column_name, column_type] = alter_column.split(":")
@@ -112,7 +112,6 @@ class RedshiftLoadCreator(OperatorCreator):
                 f"ALTER TABLE {self._output_schema_quoted}.{self._tmp_table_quoted} "
                 f"ALTER COLUMN {column_name} TYPE {column_type}"
             )
-        alter_column_commands.append("set autocommit=off")
 
         return ";\n".join(alter_column_commands)
 
@@ -139,6 +138,7 @@ class RedshiftLoadCreator(OperatorCreator):
             sql=load_cmd,
             postgres_conn_id=self._task.postgres_conn_id,
             params=self._template_parameters,
+            autocommit=True,
             **kwargs,
         )
 

--- a/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
@@ -104,7 +104,7 @@ class RedshiftLoadCreator(OperatorCreator):
         if self._alter_columns is None:
             return None
 
-        alter_column_commands = ["set autocommit on"]
+        alter_column_commands = ["set autocommit=on"]
         alter_columns = self._alter_columns.split(",")
         for alter_column in alter_columns:
             [column_name, column_type] = alter_column.split(":")
@@ -112,7 +112,7 @@ class RedshiftLoadCreator(OperatorCreator):
                 f"ALTER TABLE {self._output_schema_quoted}.{self._tmp_table_quoted} "
                 f"ALTER COLUMN {column_name} TYPE {column_type}"
             )
-        alter_column_commands.append("set autocommit off")
+        alter_column_commands.append("set autocommit=off")
 
         return ";\n".join(alter_column_commands)
 

--- a/dagger/dag_creator/airflow/operators/aws_athena_operator.py
+++ b/dagger/dag_creator/airflow/operators/aws_athena_operator.py
@@ -95,7 +95,7 @@ INSERT INTO {self.database}.{self.output_table}
         }
 
         if self.partitioned_by:
-            partitioned_by_str = ','.join([f"'{column}'" for column in self.partitioned_by])
+            partitioned_by_str = ','.join([f"'{column}'" for column in self.partitioned_by.split(',')])
             with_parameters_dict['partitioned_by'] = f"ARRAY[{partitioned_by_str}]"
 
         if self.output_format:

--- a/dagger/dag_creator/airflow/operators/redshift_sql_operator.py
+++ b/dagger/dag_creator/airflow/operators/redshift_sql_operator.py
@@ -1,0 +1,78 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence, Union
+
+from airflow.models import BaseOperator
+from airflow.providers.amazon.aws.hooks.redshift_sql import RedshiftSQLHook
+from airflow.www import utils as wwwutils
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
+
+
+class RedshiftSQLOperator(BaseOperator):
+    """
+    Executes SQL Statements against an Amazon Redshift cluster
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:RedshiftSQLOperator`
+
+    :param sql: the SQL code to be executed as a single string, or
+        a list of str (sql statements), or a reference to a template file.
+        Template references are recognized by str ending in '.sql'
+    :param redshift_conn_id: reference to
+        :ref:`Amazon Redshift connection id<howto/connection:redshift>`
+    :param parameters: (optional) the parameters to render the SQL query with.
+    :param autocommit: if True, each command is automatically committed.
+        (default value: False)
+    """
+
+    template_fields: Sequence[str] = ('sql',)
+    template_ext: Sequence[str] = ('.sql',)
+    # TODO: Remove renderer check when the provider has an Airflow 2.3+ requirement.
+    template_fields_renderers = {
+        "sql": "postgresql" if "postgresql" in wwwutils.get_attr_renderer() else "sql"
+    }
+
+    def __init__(
+        self,
+        *,
+        sql: Union[str, Iterable[str]],
+        redshift_conn_id: str = 'redshift_default',
+        parameters: Optional[Union[Iterable, Mapping]] = None,
+        autocommit: bool = True,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.redshift_conn_id = redshift_conn_id
+        self.sql = sql
+        self.autocommit = autocommit
+        self.parameters = parameters
+
+    def get_hook(self) -> RedshiftSQLHook:
+        """Create and return RedshiftSQLHook.
+        :return RedshiftSQLHook: A RedshiftSQLHook instance.
+        """
+        return RedshiftSQLHook(redshift_conn_id=self.redshift_conn_id)
+
+    def execute(self, context: 'Context') -> None:
+        """Execute a statement against Amazon Redshift"""
+        self.log.info("Executing statement: %s", self.sql)
+        hook = self.get_hook()
+        hook.run(self.sql, autocommit=self.autocommit, parameters=self.parameters, split_statements=True)

--- a/dagger/pipeline/tasks/athena_transform_task.py
+++ b/dagger/pipeline/tasks/athena_transform_task.py
@@ -53,7 +53,7 @@ class AthenaTransformTask(Task):
                 Attribute(
                     attribute_name="partitioned_by",
                     required=False,
-                    validator=list,
+                    validator=str,
                     comment="The list of fields to partition by. These fields should come last in the select statement",
                     parent_fields=["task_parameters"],
                 ),

--- a/dagger/pipeline/tasks/redshift_load_task.py
+++ b/dagger/pipeline/tasks/redshift_load_task.py
@@ -87,7 +87,7 @@ class RedshiftLoadTask(Task):
                     attribute_name="alter_columns",
                     required=False,
                     parent_fields=["task_parameters"],
-                    format_help="comma separated strings as <column_name>:<column_type>,<column_name:column_type>",
+                    format_help="comma separated strings as <column_name>:<column_type>,<column_name>:<column_type>",
                     comment="If you want to alter the column types that are inferred from the "
                             "redshift spectrum table given in the copy_ddl_from parameter"
                 ),

--- a/dagger/pipeline/tasks/redshift_load_task.py
+++ b/dagger/pipeline/tasks/redshift_load_task.py
@@ -84,6 +84,14 @@ class RedshiftLoadTask(Task):
                     comment="If you have the schema of the table e.g.: in spectrum you can copy the ddl from there",
                 ),
                 Attribute(
+                    attribute_name="alter_columns",
+                    required=False,
+                    parent_fields=["task_parameters"],
+                    format_help="comma separated strings as <column_name>:<column_type>,<column_name:column_type>",
+                    comment="If you want to alter the column types that are inferred from the "
+                            "redshift spectrum table given in the copy_ddl_from parameter"
+                ),
+                Attribute(
                     attribute_name="sort_keys",
                     required=False,
                     parent_fields=["task_parameters"],
@@ -107,6 +115,7 @@ class RedshiftLoadTask(Task):
         self._tmp_table_prefix = self.parse_attribute("tmp_table_prefix")
         self._create_table_ddl = self.parse_attribute("create_table_ddl")
         self._copy_ddl_from = self.parse_attribute("copy_ddl_from")
+        self._alter_columns = self.parse_attribute("alter_columns")
         load_parameters = self._get_default_load_params()
         if self._max_errors:
             load_parameters["maxerrors"] = self._max_errors
@@ -153,6 +162,10 @@ class RedshiftLoadTask(Task):
     @property
     def copy_ddl_from(self):
         return self._copy_ddl_from
+
+    @property
+    def alter_columns(self):
+        return self._alter_columns
 
     @property
     def sort_keys(self):


### PR DESCRIPTION
Redshift loader infers schema from glue. In glue we have dynamic length strings, but in redshift the we have fixed length strings, however sometimes the default length in the inferred schema is not long enough and that fails the redshift copy command.

With the newly added parameter we are able to alter the type of the inferred columns.