### PR TITLE
Feature/data 1300 blue gree athena transformation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @siklosid
+* @chocoapp/data-engineering

--- a/dagger/dag_creator/airflow/hooks/aws_athena_hook.py
+++ b/dagger/dag_creator/airflow/hooks/aws_athena_hook.py
@@ -97,6 +97,17 @@ class AWSAthenaHook(AwsBaseHook):
         bucket = s3.Bucket(s3_bucket)
         bucket.objects.filter(Prefix=f"{path.join(s3_path, database, table)}/").delete()
 
+    def search_tables(self, database, table_name_pattern):
+        response = self.get_glue_conn().get_tables(
+            DatabaseName=database,
+            Expression=table_name_pattern,
+            MaxResults=5
+        )
+
+        table_names = [table['Name'] for table in response['TableList']]
+
+        return table_names
+
     def run_query(self, query, query_context, result_configuration, client_request_token=None,
                   workgroup='primary'):
         """

--- a/dagger/dag_creator/airflow/operator_creators/athena_transform_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/athena_transform_creator.py
@@ -38,6 +38,7 @@ class AthenaTransformCreator(OperatorCreator):
             is_incremental=self._task.is_incremental,
             partitioned_by=self._task.partitioned_by,
             output_format=self._task.output_format,
+            blue_green_deployment=self._task.blue_green_deployment,
             workgroup=self._task.workgroup,
             params=self._template_parameters,
             **kwargs,

--- a/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
@@ -104,7 +104,7 @@ class RedshiftLoadCreator(OperatorCreator):
         if self._alter_columns is None:
             return None
 
-        alter_column_commands = []
+        alter_column_commands = ["set autocommit on"]
         alter_columns = self._alter_columns.split(",")
         for alter_column in alter_columns:
             [column_name, column_type] = alter_column.split(":")
@@ -112,6 +112,7 @@ class RedshiftLoadCreator(OperatorCreator):
                 f"ALTER TABLE {self._output_schema_quoted}.{self._tmp_table_quoted} "
                 f"ALTER COLUMN {column_name} TYPE {column_type}"
             )
+        alter_column_commands.append("set autocommit off")
 
         return ";\n".join(alter_column_commands)
 

--- a/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
@@ -2,7 +2,7 @@ from os.path import join
 from typing import Optional
 
 from dagger.dag_creator.airflow.operator_creator import OperatorCreator
-from dagger.dag_creator.airflow.operators.postgres_operator import PostgresOperator
+from dagger.dag_creator.airflow.operators.redshift_sql_operator import RedshiftSQLOperator
 
 
 class RedshiftLoadCreator(OperatorCreator):
@@ -132,14 +132,13 @@ class RedshiftLoadCreator(OperatorCreator):
     def _create_operator(self, **kwargs):
         load_cmd = self._get_cmd()
 
-        redshift_op = PostgresOperator(
+        redshift_op = RedshiftSQLOperator(
             dag=self._dag,
             task_id=self._task.name,
             sql=load_cmd,
-            postgres_conn_id=self._task.postgres_conn_id,
-            params=self._template_parameters,
+            redshift_conn_id=self._task.postgres_conn_id,
+            split_parameters=True,
             autocommit=True,
-            **kwargs,
+            **kwargs
         )
-
         return redshift_op

--- a/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
@@ -1,4 +1,5 @@
 from os.path import join
+from typing import Optional
 
 from dagger.dag_creator.airflow.operator_creator import OperatorCreator
 from dagger.dag_creator.airflow.operators.postgres_operator import PostgresOperator
@@ -23,6 +24,7 @@ class RedshiftLoadCreator(OperatorCreator):
         self._tmp_table_quoted = f"\"{self._tmp_table}\"" if self._tmp_table else None
 
         self._copy_ddl_from = self._task.copy_ddl_from
+        self._alter_columns = self._task.alter_columns
 
         self._sort_keys = self._task.sort_keys
 
@@ -35,7 +37,7 @@ class RedshiftLoadCreator(OperatorCreator):
 
         return sql_string
 
-    def _get_create_table_cmd(self):
+    def _get_create_table_cmd(self) -> Optional[str]:
         if self._tmp_table and self._task.create_table_ddl:
             ddl = self._read_sql(self._task.pipeline.directory, self._task.create_table_ddl)
             return ddl.format(schema_name=self._output_schema_quoted, table_name=self._tmp_table_quoted)
@@ -54,7 +56,7 @@ class RedshiftLoadCreator(OperatorCreator):
 
         return None
 
-    def _get_sort_key_cmd(self):
+    def _get_sort_key_cmd(self) -> Optional[str]:
         sort_key_cmd = None
         if self._sort_keys:
             sort_key_cmd =\
@@ -62,7 +64,7 @@ class RedshiftLoadCreator(OperatorCreator):
                 f"ALTER COMPOUND SORTKEY({self._sort_keys})"
         return sort_key_cmd
 
-    def _get_delete_cmd(self):
+    def _get_delete_cmd(self) -> Optional[str]:
         if self._task.incremental:
             return f"DELETE FROM {self._output_schema_quoted}.{self._output_table_quoted}" \
                    f"WHERE {self._task.delete_condition}"
@@ -72,7 +74,7 @@ class RedshiftLoadCreator(OperatorCreator):
 
         return None
 
-    def _get_load_cmd(self):
+    def _get_load_cmd(self) -> Optional[str]:
         table_name = self._tmp_table_quoted or self._output_table_quoted
         columns = "({})".format(self._task.columns) if self._task.columns else ""
         extra_parameters = "\n".join(
@@ -87,7 +89,7 @@ class RedshiftLoadCreator(OperatorCreator):
                f"iam_role '{self._task.iam_role}'\n" \
                f"{extra_parameters}"
 
-    def _get_replace_table_cmd(self):
+    def _get_replace_table_cmd(self) -> Optional[str]:
         if self._tmp_table is None:
             return None
 
@@ -98,9 +100,25 @@ class RedshiftLoadCreator(OperatorCreator):
             f"RENAME TO {self._output_table_quoted};\n" \
             f"END"
 
-    def _get_cmd(self):
+    def _get_alter_columns_cmd(self) -> Optional[str]:
+        if self._alter_columns is None:
+            return None
+
+        alter_column_commands = []
+        alter_columns = self._alter_columns.split(",")
+        for alter_column in alter_columns:
+            [column_name, column_type] = alter_column.split(":")
+            alter_column_commands.append(
+                f"ALTER TABLE {self._output_schema_quoted}.{self._tmp_table_quoted} "
+                f"ALTER COLUMN {column_name} TYPE {column_type}"
+            )
+
+        return ";\n".join(alter_column_commands)
+
+    def _get_cmd(self) -> str:
         raw_load_cmd = [
             self._get_create_table_cmd(),
+            self._get_alter_columns_cmd(),
             self._get_sort_key_cmd(),
             self._get_delete_cmd(),
             self._get_load_cmd(),

--- a/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
@@ -104,7 +104,7 @@ class RedshiftLoadCreator(OperatorCreator):
         if self._alter_columns is None:
             return None
 
-        alter_column_commands = ["set autocommit=on"]
+        alter_column_commands = []
         alter_columns = self._alter_columns.split(",")
         for alter_column in alter_columns:
             [column_name, column_type] = alter_column.split(":")
@@ -112,7 +112,6 @@ class RedshiftLoadCreator(OperatorCreator):
                 f"ALTER TABLE {self._output_schema_quoted}.{self._tmp_table_quoted} "
                 f"ALTER COLUMN {column_name} TYPE {column_type}"
             )
-        alter_column_commands.append("set autocommit=off")
 
         return ";\n".join(alter_column_commands)
 
@@ -139,6 +138,7 @@ class RedshiftLoadCreator(OperatorCreator):
             sql=load_cmd,
             postgres_conn_id=self._task.postgres_conn_id,
             params=self._template_parameters,
+            autocommit=True,
             **kwargs,
         )
 

--- a/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/redshift_load_creator.py
@@ -104,7 +104,7 @@ class RedshiftLoadCreator(OperatorCreator):
         if self._alter_columns is None:
             return None
 
-        alter_column_commands = ["set autocommit on"]
+        alter_column_commands = ["set autocommit=on"]
         alter_columns = self._alter_columns.split(",")
         for alter_column in alter_columns:
             [column_name, column_type] = alter_column.split(":")
@@ -112,7 +112,7 @@ class RedshiftLoadCreator(OperatorCreator):
                 f"ALTER TABLE {self._output_schema_quoted}.{self._tmp_table_quoted} "
                 f"ALTER COLUMN {column_name} TYPE {column_type}"
             )
-        alter_column_commands.append("set autocommit off")
+        alter_column_commands.append("set autocommit=off")
 
         return ";\n".join(alter_column_commands)
 

--- a/dagger/dag_creator/airflow/operators/aws_athena_operator.py
+++ b/dagger/dag_creator/airflow/operators/aws_athena_operator.py
@@ -95,7 +95,7 @@ INSERT INTO {self.database}.{self.output_table}
         }
 
         if self.partitioned_by:
-            partitioned_by_str = ','.join([f"'{column}'" for column in self.partitioned_by])
+            partitioned_by_str = ','.join([f"'{column}'" for column in self.partitioned_by.split(',')])
             with_parameters_dict['partitioned_by'] = f"ARRAY[{partitioned_by_str}]"
 
         if self.output_format:

--- a/dagger/dag_creator/airflow/operators/redshift_sql_operator.py
+++ b/dagger/dag_creator/airflow/operators/redshift_sql_operator.py
@@ -1,0 +1,78 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence, Union
+
+from airflow.models import BaseOperator
+from airflow.providers.amazon.aws.hooks.redshift_sql import RedshiftSQLHook
+from airflow.www import utils as wwwutils
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
+
+
+class RedshiftSQLOperator(BaseOperator):
+    """
+    Executes SQL Statements against an Amazon Redshift cluster
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:RedshiftSQLOperator`
+
+    :param sql: the SQL code to be executed as a single string, or
+        a list of str (sql statements), or a reference to a template file.
+        Template references are recognized by str ending in '.sql'
+    :param redshift_conn_id: reference to
+        :ref:`Amazon Redshift connection id<howto/connection:redshift>`
+    :param parameters: (optional) the parameters to render the SQL query with.
+    :param autocommit: if True, each command is automatically committed.
+        (default value: False)
+    """
+
+    template_fields: Sequence[str] = ('sql',)
+    template_ext: Sequence[str] = ('.sql',)
+    # TODO: Remove renderer check when the provider has an Airflow 2.3+ requirement.
+    template_fields_renderers = {
+        "sql": "postgresql" if "postgresql" in wwwutils.get_attr_renderer() else "sql"
+    }
+
+    def __init__(
+        self,
+        *,
+        sql: Union[str, Iterable[str]],
+        redshift_conn_id: str = 'redshift_default',
+        parameters: Optional[Union[Iterable, Mapping]] = None,
+        autocommit: bool = True,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.redshift_conn_id = redshift_conn_id
+        self.sql = sql
+        self.autocommit = autocommit
+        self.parameters = parameters
+
+    def get_hook(self) -> RedshiftSQLHook:
+        """Create and return RedshiftSQLHook.
+        :return RedshiftSQLHook: A RedshiftSQLHook instance.
+        """
+        return RedshiftSQLHook(redshift_conn_id=self.redshift_conn_id)
+
+    def execute(self, context: 'Context') -> None:
+        """Execute a statement against Amazon Redshift"""
+        self.log.info("Executing statement: %s", self.sql)
+        hook = self.get_hook()
+        hook.run(self.sql, autocommit=self.autocommit, parameters=self.parameters, split_statements=True)

--- a/dagger/pipeline/tasks/athena_transform_task.py
+++ b/dagger/pipeline/tasks/athena_transform_task.py
@@ -63,6 +63,13 @@ class AthenaTransformTask(Task):
                     validator=str,
                     comment="Output file format. One of PARQUET/ORC/JSON/CSV",
                     parent_fields=["task_parameters"],
+                ),
+                Attribute(
+                    attribute_name="blue_green_deployment",
+                    required=False,
+                    validator=bool,
+                    comment="Set to true for blue green deployment. Only works with non incremental transformations.",
+                    parent_fields=["task_parameters"],
                 )
             ]
         )
@@ -82,6 +89,7 @@ class AthenaTransformTask(Task):
         self._is_incremental = self.parse_attribute("is_incremental")
         self._partitioned_by = self.parse_attribute("partitioned_by")
         self._output_format = self.parse_attribute("output_format")
+        self._blue_green_deployment = self.parse_attribute("blue_green_deployment") or False
 
         self._add_hidden_s3_output()
 
@@ -116,6 +124,10 @@ class AthenaTransformTask(Task):
     @property
     def output_format(self):
         return self._output_format
+
+    @property
+    def blue_green_deployment(self):
+        return self._blue_green_deployment
 
     def _add_hidden_s3_output(self):
         output_athena = self._outputs[0]

--- a/dagger/pipeline/tasks/athena_transform_task.py
+++ b/dagger/pipeline/tasks/athena_transform_task.py
@@ -53,7 +53,7 @@ class AthenaTransformTask(Task):
                 Attribute(
                     attribute_name="partitioned_by",
                     required=False,
-                    validator=list,
+                    validator=str,
                     comment="The list of fields to partition by. These fields should come last in the select statement",
                     parent_fields=["task_parameters"],
                 ),

--- a/dagger/pipeline/tasks/redshift_load_task.py
+++ b/dagger/pipeline/tasks/redshift_load_task.py
@@ -84,6 +84,14 @@ class RedshiftLoadTask(Task):
                     comment="If you have the schema of the table e.g.: in spectrum you can copy the ddl from there",
                 ),
                 Attribute(
+                    attribute_name="alter_columns",
+                    required=False,
+                    parent_fields=["task_parameters"],
+                    format_help="comma separated strings as <column_name>:<column_type>,<column_name>:<column_type>",
+                    comment="If you want to alter the column types that are inferred from the "
+                            "redshift spectrum table given in the copy_ddl_from parameter"
+                ),
+                Attribute(
                     attribute_name="sort_keys",
                     required=False,
                     parent_fields=["task_parameters"],
@@ -107,6 +115,7 @@ class RedshiftLoadTask(Task):
         self._tmp_table_prefix = self.parse_attribute("tmp_table_prefix")
         self._create_table_ddl = self.parse_attribute("create_table_ddl")
         self._copy_ddl_from = self.parse_attribute("copy_ddl_from")
+        self._alter_columns = self.parse_attribute("alter_columns")
         load_parameters = self._get_default_load_params()
         if self._max_errors:
             load_parameters["maxerrors"] = self._max_errors
@@ -153,6 +162,10 @@ class RedshiftLoadTask(Task):
     @property
     def copy_ddl_from(self):
         return self._copy_ddl_from
+
+    @property
+    def alter_columns(self):
+        return self._alter_columns
 
     @property
     def sort_keys(self):


### PR DESCRIPTION
**JIRA Ticket:**
[DATA-1300](https://choco.atlassian.net/browse/DATA-1300)

**Notes**
1. Adding new boolean attribute to flag if we want to do blue green deployment for non incremental athena transformations
2. Adding logic to implement blue green. The idea is that we are crating staging tables with randomised table names like `__<original output_table_name>_random_sequence` and when it's ready we are just pointing a view to the newly created table.
3. As a last step we clean up the old tables. For this step even before we run the new tansformations, we store all the tables that has the `__<original output_table_name>_*` pattern and then at the end if all previous steps are successful then drop them.

Tested fully from local airflow running on staging environment.