### PR TITLE
Quickfix/fixing external sensor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.7.4-slim-stretch
+FROM python:3.7.4-slim-stretch@sha256:34a714dec6e3387e964350dc09d9db95f16df3720d018c9ca024c1e4e20c118b
+RUN apt-get update -yq && apt-get upgrade -yq && rm -rf /var/lib/apt/lists/*
 
 # Add your envrionment variables
 #ARG ACCESS_KEY_ID

--- a/dagger/alerts/alert.py
+++ b/dagger/alerts/alert.py
@@ -2,6 +2,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import List
 
+from airflow.utils.types import DagRunType
 from slack.web.client import WebClient
 from dagger import conf
 from dagger.utilities.config_validator import Attribute, ConfigValidator
@@ -98,9 +99,9 @@ def get_task_run_time(task_instance):
 def airflow_task_fail_alerts(alerts: List[AlertBase], context):
     if conf.ENV == "datatst":
         return
-    if context["dag_run"].external_trigger is True:
+    if context["dag_run"].run_type == DagRunType.MANUAL:
         return
-    if context["dag"].is_paused is True:
+    if getattr(context["dag"], "is_paused", False):
         return
 
     task_instance = context["task_instance"]

--- a/dagger/alerts/alert.py
+++ b/dagger/alerts/alert.py
@@ -114,7 +114,7 @@ def airflow_task_fail_alerts(alerts: List[AlertBase], context):
         alert.execute(
             task_instance.dag_id,
             task_instance.task_id,
-            context["execution_date"],
+            context.get("logical_date", context.get("execution_date")),
             run_time,
             task_instance.log_url,
         )

--- a/dagger/dag_creator/airflow/dag_creator.py
+++ b/dagger/dag_creator/airflow/dag_creator.py
@@ -104,7 +104,7 @@ class DagCreator(GraphTraverserBase):
             description=pipeline.description,
             default_args=default_args,
             start_date=pipeline.start_date,
-            schedule_interval=pipeline.schedule,
+            schedule=pipeline.schedule,
             user_defined_macros=user_defined_macros,
             **pipeline.parameters,
         )

--- a/dagger/dag_creator/airflow/dag_creator.py
+++ b/dagger/dag_creator/airflow/dag_creator.py
@@ -35,8 +35,8 @@ class DagCreator(GraphTraverserBase):
 
     @staticmethod
     def _get_execution_date_fn(from_dag_schedule: str, to_dag_schedule: str):
-        def execution_date_fn(execution_date, **kwargs):
-            to_dag_cron = croniter.croniter(to_dag_schedule, execution_date)
+        def execution_date_fn(logical_date, **kwargs):
+            to_dag_cron = croniter.croniter(to_dag_schedule, logical_date)
             to_dag_next_schedule = to_dag_cron.get_next(datetime)
 
             from_dag_cron = croniter.croniter(from_dag_schedule, to_dag_next_schedule)

--- a/dagger/dag_creator/airflow/dag_creator.py
+++ b/dagger/dag_creator/airflow/dag_creator.py
@@ -1,14 +1,15 @@
 import re
-from datetime import timedelta, datetime
+from datetime import timedelta
 from functools import partial
 
 from airflow import DAG
-from airflow.sensors.external_task import ExternalTaskSensor
 
-import croniter
 from dagger import conf
 from dagger.alerts.alert import airflow_task_fail_alerts
 from dagger.dag_creator.airflow.operator_factory import OperatorFactory
+from dagger.dag_creator.airflow.sensors.cron_aware_external_task_sensor import (
+    CronAwareExternalTaskSensor,
+)
 from dagger.dag_creator.airflow.utils.macros import user_defined_macros
 from dagger.dag_creator.graph_traverser_base import GraphTraverserBase
 from dagger.graph.task_graph import Graph, Node
@@ -33,22 +34,6 @@ class DagCreator(GraphTraverserBase):
             "retry_delay": timedelta(minutes=5),
         }
 
-    @staticmethod
-    def _get_execution_date_fn(from_dag_schedule: str, to_dag_schedule: str):
-        def execution_date_fn(logical_date, **kwargs):
-            to_dag_cron = croniter.croniter(to_dag_schedule, logical_date)
-            to_dag_next_schedule = to_dag_cron.get_next(datetime)
-
-            from_dag_cron = croniter.croniter(from_dag_schedule, to_dag_next_schedule)
-            from_dag_cron.get_next(datetime)
-            # skipping one schedule
-            from_dag_cron.get_prev(datetime)
-            from_dag_target_schedule = from_dag_cron.get_prev(datetime)
-
-            return from_dag_target_schedule
-
-        return execution_date_fn
-
     def _get_external_task_sensor_name_dict(self, from_task_id: str) -> dict:
         from_pipeline_name = self._task_graph.get_node(from_task_id).obj.pipeline_name
         from_task_name = self._task_graph.get_node(from_task_id).obj.name
@@ -58,7 +43,7 @@ class DagCreator(GraphTraverserBase):
             "external_sensor_name": f"{from_pipeline_name}-{from_task_name}-sensor",
         }
 
-    def _get_external_task_sensor(self, from_task_id: str, to_task_id: str, follow_external_dependency: dict) -> ExternalTaskSensor:
+    def _get_external_task_sensor(self, from_task_id: str, to_task_id: str, follow_external_dependency: dict) -> CronAwareExternalTaskSensor:
         """
         create an object of external task sensor for a specific from_task_id and to_task_id
         """
@@ -75,14 +60,13 @@ class DagCreator(GraphTraverserBase):
         extra_args = conf.EXTERNAL_SENSOR_DEFAULT_ARGS.copy()
         extra_args.update(follow_external_dependency)
 
-        return ExternalTaskSensor(
+        return CronAwareExternalTaskSensor(
             dag=self._dags[to_pipe_id],
             task_id=external_sensor_name,
             external_dag_id=from_pipeline_name,
             external_task_id=from_task_name,
-            execution_date_fn=self._get_execution_date_fn(
-                from_pipeline_schedule, to_pipeline_schedule
-            ),
+            from_schedule=from_pipeline_schedule,
+            to_schedule=to_pipeline_schedule,
             **extra_args
         )
 

--- a/dagger/dag_creator/airflow/hooks/sqoop_hook.py
+++ b/dagger/dag_creator/airflow/hooks/sqoop_hook.py
@@ -26,7 +26,7 @@ import subprocess
 from copy import deepcopy
 
 from airflow.exceptions import AirflowException
-from airflow.hooks.base_hook import BaseHook
+from airflow.hooks.base import BaseHook
 
 
 class SqoopHook(BaseHook):

--- a/dagger/dag_creator/airflow/operator_creators/airflow_op_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/airflow_op_creator.py
@@ -26,7 +26,6 @@ class AirflowOpCreator(OperatorCreator):
                 importlib.import_module(python_module), self._task.function
             )
             params["python_callable"] = python_function
-            params["provide_context"] = True
             params["op_kwargs"] = self._template_parameters
 
         batch_op = operator_class(dag=self._dag, task_id=self._task.name, **params)

--- a/dagger/dag_creator/airflow/operator_creators/dummy_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/dummy_creator.py
@@ -1,4 +1,4 @@
-from airflow.operators.dummy_operator import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from dagger.dag_creator.airflow.operator_creator import OperatorCreator
 
 
@@ -11,4 +11,4 @@ class DummyCreator(OperatorCreator):
     def _create_operator(self, **kwargs):
         params = {**kwargs}
 
-        return DummyOperator(dag=self._dag, task_id=self._task.name, **params)
+        return EmptyOperator(dag=self._dag, task_id=self._task.name, **params)

--- a/dagger/dag_creator/airflow/operator_creators/python_creator.py
+++ b/dagger/dag_creator/airflow/operator_creators/python_creator.py
@@ -1,7 +1,7 @@
 import importlib
 from os import path
 
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from dagger import conf
 from dagger.dag_creator.airflow.operator_creator import OperatorCreator
 
@@ -28,7 +28,6 @@ class PythonCreator(OperatorCreator):
             dag=self._dag,
             task_id=self._task.name,
             python_callable=python_function,
-            provide_context=True,
             op_kwargs=self._template_parameters,
             **params,
         )

--- a/dagger/dag_creator/airflow/operator_factory.py
+++ b/dagger/dag_creator/airflow/operator_factory.py
@@ -1,4 +1,4 @@
-from airflow.operators.dummy_operator import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from dagger.dag_creator.airflow.operator_creator import OperatorCreator
 from dagger.dag_creator.airflow.operator_creators import (
     airflow_op_creator,
@@ -20,7 +20,7 @@ from dagger.dag_creator.airflow.utils.operator_factories import make_control_flo
 from dagger.utilities.classes import get_deep_obj_subclasses
 
 
-class DataOperator(DummyOperator):
+class DataOperator(EmptyOperator):
     ui_color = "#e8f7e4"
 
     def __init__(self, *args, **kwargs):

--- a/dagger/dag_creator/airflow/operators/aws_athena_operator.py
+++ b/dagger/dag_creator/airflow/operators/aws_athena_operator.py
@@ -21,7 +21,6 @@
 from uuid import uuid4
 
 from dagger.dag_creator.airflow.operators.dagger_base_operator import DaggerBaseOperator
-from airflow.utils.decorators import apply_defaults
 from dagger.dag_creator.airflow.hooks.aws_athena_hook import AWSAthenaHook
 from dagger.utilities.randomise import generate_random_name
 from tenacity import retry, stop_after_attempt, wait_fixed
@@ -53,7 +52,6 @@ class AWSAthenaOperator(DaggerBaseOperator):
     template_fields = ('query', 'database', 'output_location')
     template_ext = ('.sql', )
 
-    @apply_defaults
     def __init__(self, query, database, s3_tmp_results_location, s3_output_location, output_table, is_incremental,
                  partitioned_by=None, output_format=None, aws_conn_id='aws_default', client_request_token=None,
                  query_execution_context=None, result_configuration=None, sleep_time=30, max_tries=None,

--- a/dagger/dag_creator/airflow/operators/aws_glue_job_operator.py
+++ b/dagger/dag_creator/airflow/operators/aws_glue_job_operator.py
@@ -19,8 +19,7 @@
 from typing import Optional
 
 from dagger.dag_creator.airflow.operators.dagger_base_operator import DaggerBaseOperator
-from airflow.utils.decorators import apply_defaults
-from airflow.contrib.hooks.aws_hook import AwsHook
+from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.exceptions import AirflowException
 
 from dagger.dag_creator.airflow.utils.decorators import lazy_property
@@ -48,7 +47,6 @@ class AwsGlueJobOperator(DaggerBaseOperator):
     template_ext = ()
     ui_color = '#ededed'
 
-    @apply_defaults
     def __init__(
         self,
         *,
@@ -66,7 +64,7 @@ class AwsGlueJobOperator(DaggerBaseOperator):
 
     @lazy_property
     def logs_client(self):
-        return AwsHook(aws_conn_id=self.aws_conn_id, client_type="logs").get_client_type(
+        return AwsBaseHook(aws_conn_id=self.aws_conn_id, client_type="logs").get_client_type(
             "logs", region_name=self.region_name
         )
 

--- a/dagger/dag_creator/airflow/operators/dagger_base_operator.py
+++ b/dagger/dag_creator/airflow/operators/dagger_base_operator.py
@@ -1,9 +1,7 @@
 from airflow.models import BaseOperator
-from airflow.utils.decorators import apply_defaults
 
 
 class DaggerBaseOperator(BaseOperator):
-    @apply_defaults
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/dagger/dag_creator/airflow/operators/postgres_operator.py
+++ b/dagger/dag_creator/airflow/operators/postgres_operator.py
@@ -1,7 +1,6 @@
 from typing import Iterable, Mapping, Optional, Union
 
 from airflow.providers.postgres.hooks.postgres import PostgresHook
-from airflow.utils.decorators import apply_defaults
 from dagger.dag_creator.airflow.operators.dagger_base_operator import DaggerBaseOperator
 
 
@@ -28,7 +27,6 @@ class PostgresOperator(DaggerBaseOperator):
     template_ext = (".sql",)
     ui_color = "#ededed"
 
-    @apply_defaults
     def __init__(
         self,
         sql: str,

--- a/dagger/dag_creator/airflow/operators/redshift_sql_operator.py
+++ b/dagger/dag_creator/airflow/operators/redshift_sql_operator.py
@@ -19,7 +19,6 @@ from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence, Union
 
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.redshift_sql import RedshiftSQLHook
-from airflow.www import utils as wwwutils
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -45,10 +44,7 @@ class RedshiftSQLOperator(BaseOperator):
 
     template_fields: Sequence[str] = ('sql',)
     template_ext: Sequence[str] = ('.sql',)
-    # TODO: Remove renderer check when the provider has an Airflow 2.3+ requirement.
-    template_fields_renderers = {
-        "sql": "postgresql" if "postgresql" in wwwutils.get_attr_renderer() else "sql"
-    }
+    template_fields_renderers = {"sql": "postgresql"}
 
     def __init__(
         self,

--- a/dagger/dag_creator/airflow/operators/snowflake_operator.py
+++ b/dagger/dag_creator/airflow/operators/snowflake_operator.py
@@ -1,5 +1,4 @@
-from airflow.contrib.hooks.snowflake_hook import SnowflakeHook
-from airflow.utils.decorators import apply_defaults
+from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook  # noqa: requires apache-airflow-providers-snowflake
 from dagger.dag_creator.airflow.operators.dagger_base_operator import DaggerBaseOperator
 
 
@@ -30,7 +29,6 @@ class SnowflakeOperator(DaggerBaseOperator):
     template_ext = (".sql",)
     ui_color = "#ededed"
 
-    @apply_defaults
     def __init__(
         self,
         sql,

--- a/dagger/dag_creator/airflow/operators/spark_submit_operator.py
+++ b/dagger/dag_creator/airflow/operators/spark_submit_operator.py
@@ -4,8 +4,6 @@ import time
 
 import boto3
 from airflow.exceptions import AirflowException
-from airflow.utils.decorators import apply_defaults
-
 from dagger.dag_creator.airflow.operators.dagger_base_operator import DaggerBaseOperator
 
 ENV = os.environ["ENV"].lower()
@@ -16,7 +14,6 @@ class SparkSubmitOperator(DaggerBaseOperator):
     ui_color = "bisque"
     template_fields = ("job_args", "spark_args", "spark_conf_args")
 
-    @apply_defaults
     def __init__(
         self,
         job_file,

--- a/dagger/dag_creator/airflow/operators/sqoop_operator.py
+++ b/dagger/dag_creator/airflow/operators/sqoop_operator.py
@@ -2,7 +2,6 @@ import os
 import signal
 
 from airflow.exceptions import AirflowException
-from airflow.utils.decorators import apply_defaults
 from dagger.dag_creator.airflow.hooks.sqoop_hook import SqoopHook
 from dagger.dag_creator.airflow.operators.dagger_base_operator import DaggerBaseOperator
 
@@ -42,7 +41,6 @@ class SqoopOperator(DaggerBaseOperator):
     )
     ui_color = "#7D8CA4"
 
-    @apply_defaults
     def __init__(
         self,
         conn_id="sqoop_default",

--- a/dagger/dag_creator/airflow/sensors/cron_aware_external_task_sensor.py
+++ b/dagger/dag_creator/airflow/sensors/cron_aware_external_task_sensor.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+
+import croniter
+from airflow.sensors.external_task import ExternalTaskSensor
+
+
+class CronAwareExternalTaskSensor(ExternalTaskSensor):
+    """
+    ExternalTaskSensor that derives the upstream logical_date from two cron schedules.
+
+    Stores ``from_schedule`` and ``to_schedule`` as serializable string attributes so
+    behavior survives Airflow 3.x DAG serialization, where ``execution_date_fn`` closures
+    are stringified and lose their captured variables.
+    """
+
+    template_fields = ExternalTaskSensor.template_fields + ["from_schedule", "to_schedule"]
+
+    def __init__(self, *, from_schedule: str, to_schedule: str, **kwargs):
+        super().__init__(**kwargs)
+        self.from_schedule = from_schedule
+        self.to_schedule = to_schedule
+
+    def _get_dttm_filter(self, context):
+        logical_date = context["logical_date"]
+
+        to_dag_cron = croniter.croniter(self.to_schedule, logical_date)
+        to_dag_next_schedule = to_dag_cron.get_next(datetime)
+
+        from_dag_cron = croniter.croniter(self.from_schedule, to_dag_next_schedule)
+        from_dag_cron.get_next(datetime)
+        from_dag_cron.get_prev(datetime)
+        from_dag_target_schedule = from_dag_cron.get_prev(datetime)
+
+        return [from_dag_target_schedule]

--- a/dagger/dag_creator/airflow/utils/operator_factories.py
+++ b/dagger/dag_creator/airflow/utils/operator_factories.py
@@ -1,13 +1,12 @@
 from functools import partial
 
-from airflow.operators.python_operator import ShortCircuitOperator
+from airflow.operators.python import ShortCircuitOperator
 
 
 def make_control_flow(is_dummy_operator_short_circuit, dag):
     control_flow = ShortCircuitOperator(
         task_id="dummy-control-flow",
         dag=dag,
-        provide_context=True,
         python_callable=partial(eval_control_flow, is_dummy_operator_short_circuit),
     )
     return control_flow

--- a/dagger/dag_creator/airflow/utils/slack_alerts.py
+++ b/dagger/dag_creator/airflow/utils/slack_alerts.py
@@ -1,7 +1,7 @@
 import os
 
-from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperator
-from airflow.hooks.base_hook import BaseHook
+from airflow.providers.slack.operators.slack_webhook import SlackWebhookOperator
+from airflow.hooks.base import BaseHook
 
 SLACK_CONN_ID = "slack"
 ENV = os.environ["ENV"].lower()
@@ -38,7 +38,7 @@ def task_success_slack_alert(context):
         task=context["task_instance"].task_id,
         dag=context["task_instance"].dag_id,
         ti=context["task_instance"],
-        exec_date=context["execution_date"],
+        exec_date=context.get("logical_date", context.get("execution_date")),
         run_time=get_task_run_time(context["task_instance"]),
         log_url=context["task_instance"].log_url,
     )
@@ -81,7 +81,7 @@ def task_fail_slack_alert(context):
         task=context["task_instance"].task_id,
         dag=context["task_instance"].dag_id,
         ti=context["task_instance"],
-        exec_date=context["execution_date"],
+        exec_date=context.get("logical_date", context.get("execution_date")),
         run_time=get_task_run_time(context["task_instance"]),
         log_url=context["task_instance"].log_url,
     )

--- a/dagger/dag_creator/airflow/utils/slack_alerts.py
+++ b/dagger/dag_creator/airflow/utils/slack_alerts.py
@@ -1,7 +1,7 @@
 import os
 
 from airflow.providers.slack.operators.slack_webhook import SlackWebhookOperator
-from airflow.hooks.base import BaseHook
+from airflow.utils.types import DagRunType
 
 SLACK_CONN_ID = "slack"
 ENV = os.environ["ENV"].lower()
@@ -9,6 +9,16 @@ ENV = os.environ["ENV"].lower()
 
 def get_task_run_time(task_instance):
     return (task_instance.end_date - task_instance.start_date).total_seconds()
+
+
+def _should_skip_alert(context):
+    if ENV == "datatst":
+        return True
+    if context["dag_run"].run_type == DagRunType.MANUAL:
+        return True
+    if getattr(context["dag"], "is_paused", False):
+        return True
+    return False
 
 
 def task_success_slack_alert(context):
@@ -19,14 +29,9 @@ def task_success_slack_alert(context):
     Returns:
         None: Calls the SlackWebhookOperator execute method internally
     """
-    if ENV == "datatst":
-        return
-    if context["dag_run"].external_trigger is True:
-        return
-    if context["dag"].is_paused is True:
+    if _should_skip_alert(context):
         return
 
-    slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
     slack_msg = """
             :large_blue_circle: Task Succeeded!
             *Task*: {task}
@@ -45,8 +50,7 @@ def task_success_slack_alert(context):
 
     success_alert = SlackWebhookOperator(
         task_id="slack_test",
-        http_conn_id="slack",
-        webhook_token=slack_webhook_token,
+        slack_webhook_conn_id=SLACK_CONN_ID,
         message=slack_msg,
         username="airflow",
     )
@@ -62,14 +66,9 @@ def task_fail_slack_alert(context):
     Returns:
         None: Calls the SlackWebhookOperator execute method internally
     """
-    if ENV == "datatst":
-        return
-    if context["dag_run"].external_trigger is True:
-        return
-    if context["dag"].is_paused is True:
+    if _should_skip_alert(context):
         return
 
-    slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
     slack_msg = """
             :red_circle: Task Failed.
             *Task*: {task}
@@ -88,8 +87,7 @@ def task_fail_slack_alert(context):
 
     failed_alert = SlackWebhookOperator(
         task_id=context["task_instance"].task_id,
-        http_conn_id=SLACK_CONN_ID,
-        webhook_token=slack_webhook_token,
+        slack_webhook_conn_id=SLACK_CONN_ID,
         message=slack_msg,
         username="airflow",
     )

--- a/dockers/airflow/Dockerfile
+++ b/dockers/airflow/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.7-slim@sha256:b53f496ca43e5af6994f8e316cf03af31050bf7944e0e4a308ad86c001cf028b
 
 # Image arguments and variables
 ARG AIRFLOW_VERSION

--- a/dockers/dagger_ui/Dockerfile
+++ b/dockers/dagger_ui/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.8-slim
+FROM python:3.8-slim@sha256:1d52838af602b4b5a831beb13a0e4d073280665ea7be7f69ce2382f29c5a613f
+RUN apt-get update -yq && apt-get upgrade -yq && rm -rf /var/lib/apt/lists/*
 
 ENV DAGGER_HOME /usr/local/dagger
 ENV PYTHONPATH /usr/local/dagger

--- a/tests/dag_creator/airflow/test_dag_creator.py
+++ b/tests/dag_creator/airflow/test_dag_creator.py
@@ -5,6 +5,9 @@ from dagger import conf
 from dagger.config_finder.config_finder import ConfigFinder
 from dagger.config_finder.config_processor import ConfigProcessor
 from dagger.dag_creator.airflow.dag_creator import DagCreator
+from dagger.dag_creator.airflow.sensors.cron_aware_external_task_sensor import (
+    CronAwareExternalTaskSensor,
+)
 from dagger.graph.task_graph import TaskGraph
 
 from airflow.utils.dot_renderer import render_dag
@@ -76,8 +79,8 @@ class TestDagCreator(unittest.TestCase):
         dot = render_dag(test_external_sensor_dag)
         self.assertEqual(dot.source, self.dot_test_external_sensor)
 
-    def test_get_execution_delta_fn(self):
-        execution_date = datetime(2021, 12, 28, 18, 30)
+    def test_cron_aware_external_task_sensor_dttm(self):
+        logical_date = datetime(2021, 12, 28, 18, 30)
         test_cases = [
             # (from_dag_schedule, to_dag_schedule, expected_result)
             ("0 * * * *", "30 * * * *", datetime(2021, 12, 28, 18, 0)),  # both hourly with different minutes
@@ -89,11 +92,18 @@ class TestDagCreator(unittest.TestCase):
             ("30 19 * * *", "30 * * * *", datetime(2021, 12, 27, 19, 30)),  # from daily to hourly with same minutes
         ]
 
-        for test_case in test_cases:
-            from_dag_schedule, to_dag_schedule, expected_result = test_case
-
-            execution_delta_fn = DagCreator._get_execution_date_fn(from_dag_schedule, to_dag_schedule)
-            self.assertEqual(execution_delta_fn(execution_date), expected_result)
+        for from_dag_schedule, to_dag_schedule, expected_result in test_cases:
+            sensor = CronAwareExternalTaskSensor(
+                task_id="test_sensor",
+                external_dag_id="from_dag",
+                external_task_id="from_task",
+                from_schedule=from_dag_schedule,
+                to_schedule=to_dag_schedule,
+            )
+            self.assertEqual(
+                sensor._get_dttm_filter({"logical_date": logical_date}),
+                [expected_result],
+            )
 
     def test_disable_task(self):
         dag_creator = DagCreator(self.task_graph._graph, with_data_nodes=True)


### PR DESCRIPTION
 Summary:                                                                                                                                                                                                                                                           
  - The closure-based execution_date_fn passed to ExternalTaskSensor no longer worked in Airflow 3.x. Airflow serializes callables as source-code strings (airflow/serialization/serialized_objects.py — str(get_python_source(var))), and in 3.x the worker hydrates
   tasks from the serialized form, so the closure (and its captured from_dag_schedule / to_dag_schedule) is lost. _get_dttm_filter then falls through to [logical_date], producing the "delta = 0" behavior visible in the UI.                                       
  - Replaced the closure with a CronAwareExternalTaskSensor subclass that stores both cron schedules as plain string attributes (declared as template fields so they render in the UI) and overrides _get_dttm_filter with the same croniter logic. Strings serialize
   cleanly, the method lives on the class, so 3.x reconstruction preserves behavior.                                                                                                                                                                                 
                                                                                                                                                                                                                                                                     
  Changes:
  - New: dagger/dag_creator/airflow/sensors/cron_aware_external_task_sensor.py — the subclass.                                                                                                                                                                       
  - dagger/dag_creator/airflow/dag_creator.py — drops _get_execution_date_fn and the croniter / datetime / ExternalTaskSensor imports; uses CronAwareExternalTaskSensor(from_schedule=..., to_schedule=...).                                                         
  - tests/dag_creator/airflow/test_dag_creator.py — renames the test and exercises _get_dttm_filter directly on the new sensor across all 7 schedule pairs.                                                 
                                                                                                                                                                                                                                                                     
  Test plan:                                                                                                                                                                                                                                                         
  - make test passes (locally: 99 passed, 2 skipped).                                                                                                                                                                                                                
  - In a real Airflow 3.x deployment, open a sensor task in the UI → "Rendered Template" view shows from_schedule and to_schedule.                                                                                                                                   
  - Verify the sensor actually pokes the upstream DAG at the cron-derived logical_date (not the same timestamp as the downstream task).      